### PR TITLE
LPS-137222 Revert SF from raylife-d2c-web and add new advice on readme

### DIFF
--- a/modules/apps/site/site-insurance-site-initializer/remote-web-components/raylife-d2c-web/README.markdown
+++ b/modules/apps/site/site-insurance-site-initializer/remote-web-components/raylife-d2c-web/README.markdown
@@ -12,6 +12,11 @@ npm install
 yarn install
 ```
 
+### Requirement
+
+React >= **17.0.2**
+React-DOM >= **17.0.2**
+
 ### Development
 
 Start the react application with:

--- a/modules/apps/site/site-insurance-site-initializer/remote-web-components/raylife-d2c-web/package.json
+++ b/modules/apps/site/site-insurance-site-initializer/remote-web-components/raylife-d2c-web/package.json
@@ -1,163 +1,164 @@
+
 {
-	"babel": {
-		"presets": [
-			"react-app"
-		]
-	},
-	"browserslist": {
-		"development": [
-			"last 1 chrome version",
-			"last 1 firefox version",
-			"last 1 safari version"
-		],
-		"production": [
-			">0.2%",
-			"not dead",
-			"not op_mini all"
-		]
-	},
-	"dependencies": {
-		"@babel/core": "7.12.3",
-		"@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
-		"@svgr/webpack": "5.5.0",
-		"@testing-library/jest-dom": "^5.11.4",
-		"@testing-library/react": "^11.1.0",
-		"@testing-library/user-event": "^12.1.10",
-		"@typescript-eslint/eslint-plugin": "^4.5.0",
-		"@typescript-eslint/parser": "^4.5.0",
-		"axios": "^0.21.1",
-		"babel-eslint": "^10.1.0",
-		"babel-jest": "^26.6.0",
-		"babel-loader": "8.1.0",
-		"babel-plugin-named-asset-import": "^0.3.7",
-		"babel-preset-react-app": "^10.0.0",
-		"bfj": "^7.0.2",
-		"camelcase": "^6.1.0",
-		"case-sensitive-paths-webpack-plugin": "2.3.0",
-		"css-loader": "4.3.0",
-		"dotenv": "8.2.0",
-		"dotenv-expand": "5.1.0",
-		"eslint": "^7.11.0",
-		"eslint-config-react-app": "^6.0.0",
-		"eslint-plugin-flowtype": "^5.2.0",
-		"eslint-plugin-import": "^2.22.1",
-		"eslint-plugin-jest": "^24.1.0",
-		"eslint-plugin-jsx-a11y": "^6.3.1",
-		"eslint-plugin-react": "^7.21.5",
-		"eslint-plugin-react-hooks": "^4.2.0",
-		"eslint-plugin-testing-library": "^3.9.2",
-		"eslint-webpack-plugin": "^2.5.2",
-		"file-loader": "6.1.1",
-		"fs-extra": "^9.0.1",
-		"html-webpack-plugin": "4.5.0",
-		"identity-obj-proxy": "3.0.0",
-		"jest": "26.6.0",
-		"jest-circus": "26.6.0",
-		"jest-resolve": "26.6.0",
-		"jest-watch-typeahead": "0.6.1",
-		"js-cookie": "^2.2.1",
-		"lodash.debounce": "^4.0.8",
-		"mini-css-extract-plugin": "0.11.3",
-		"node-sass": "^6.0.1",
-		"optimize-css-assets-webpack-plugin": "5.0.4",
-		"pnp-webpack-plugin": "1.6.4",
-		"polished": "^4.1.3",
-		"postcss-flexbugs-fixes": "4.2.1",
-		"postcss-loader": "3.0.0",
-		"postcss-normalize": "8.0.1",
-		"postcss-preset-env": "6.7.0",
-		"postcss-safe-parser": "5.0.2",
-		"prompts": "2.4.0",
-		"react": "16.12.0",
-		"react-app-polyfill": "^2.0.0",
-		"react-dev-utils": "^11.0.3",
-		"react-dom": "16.12.0",
-		"react-hook-form": "^7.8.8",
-		"react-number-format": "^4.6.3",
-		"react-refresh": "^0.8.3",
-		"resolve": "1.18.1",
-		"resolve-url-loader": "^3.1.2",
-		"sass-loader": "^10.0.5",
-		"semver": "7.3.2",
-		"style-loader": "1.3.0",
-		"terser-webpack-plugin": "4.2.3",
-		"ts-pnp": "1.2.0",
-		"url-loader": "4.1.1",
-		"web-vitals": "^1.0.1",
-		"webpack": "4.44.2",
-		"webpack-dev-server": "3.11.1",
-		"webpack-manifest-plugin": "2.2.0",
-		"workbox-webpack-plugin": "5.1.4"
-	},
+	"name": "d2c.web",
+	"version": "0.1.0",
 	"description": "D2C Web",
-	"devDependencies": {
-		"json-server": "^0.16.3",
-		"sass-to-string": "^1.5.1"
+	"private": true,
+	"dependencies": {
+	  "@babel/core": "7.12.3",
+	  "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
+	  "@svgr/webpack": "5.5.0",
+	  "@testing-library/jest-dom": "^5.11.4",
+	  "@testing-library/react": "^11.1.0",
+	  "@testing-library/user-event": "^12.1.10",
+	  "@typescript-eslint/eslint-plugin": "^4.5.0",
+	  "@typescript-eslint/parser": "^4.5.0",
+	  "axios": "^0.21.1",
+	  "babel-eslint": "^10.1.0",
+	  "babel-jest": "^26.6.0",
+	  "babel-loader": "8.1.0",
+	  "babel-plugin-named-asset-import": "^0.3.7",
+	  "babel-preset-react-app": "^10.0.0",
+	  "bfj": "^7.0.2",
+	  "camelcase": "^6.1.0",
+	  "case-sensitive-paths-webpack-plugin": "2.3.0",
+	  "css-loader": "4.3.0",
+	  "dotenv": "8.2.0",
+	  "dotenv-expand": "5.1.0",
+	  "eslint": "^7.11.0",
+	  "eslint-config-react-app": "^6.0.0",
+	  "eslint-plugin-flowtype": "^5.2.0",
+	  "eslint-plugin-import": "^2.22.1",
+	  "eslint-plugin-jest": "^24.1.0",
+	  "eslint-plugin-jsx-a11y": "^6.3.1",
+	  "eslint-plugin-react": "^7.21.5",
+	  "eslint-plugin-react-hooks": "^4.2.0",
+	  "eslint-plugin-testing-library": "^3.9.2",
+	  "eslint-webpack-plugin": "^2.5.2",
+	  "file-loader": "6.1.1",
+	  "fs-extra": "^9.0.1",
+	  "html-webpack-plugin": "4.5.0",
+	  "identity-obj-proxy": "3.0.0",
+	  "jest": "26.6.0",
+	  "jest-circus": "26.6.0",
+	  "jest-resolve": "26.6.0",
+	  "jest-watch-typeahead": "0.6.1",
+	  "js-cookie": "^2.2.1",
+	  "lodash.debounce": "^4.0.8",
+	  "mini-css-extract-plugin": "0.11.3",
+	  "node-sass": "^6.0.1",
+	  "optimize-css-assets-webpack-plugin": "5.0.4",
+	  "pnp-webpack-plugin": "1.6.4",
+	  "polished": "^4.1.3",
+	  "postcss-flexbugs-fixes": "4.2.1",
+	  "postcss-loader": "3.0.0",
+	  "postcss-normalize": "8.0.1",
+	  "postcss-preset-env": "6.7.0",
+	  "postcss-safe-parser": "5.0.2",
+	  "prompts": "2.4.0",
+	  "react": "^17.0.2",
+	  "react-app-polyfill": "^2.0.0",
+	  "react-dev-utils": "^11.0.3",
+	  "react-dom": "^17.0.2",
+	  "react-hook-form": "^7.8.8",
+	  "react-number-format": "^4.6.3",
+	  "react-refresh": "^0.8.3",
+	  "resolve": "1.18.1",
+	  "resolve-url-loader": "^3.1.2",
+	  "sass-loader": "^10.0.5",
+	  "semver": "7.3.2",
+	  "style-loader": "1.3.0",
+	  "terser-webpack-plugin": "4.2.3",
+	  "ts-pnp": "1.2.0",
+	  "url-loader": "4.1.1",
+	  "web-vitals": "^1.0.1",
+	  "webpack": "4.44.2",
+	  "webpack-dev-server": "3.11.1",
+	  "webpack-manifest-plugin": "2.2.0",
+	  "workbox-webpack-plugin": "5.1.4"
+	},
+	"scripts": {
+	  "start": "node scripts/start.js",
+	  "build": "node scripts/build.js",
+	  "build:liferay": "yarn build && ./setup-liferay.sh",
+	  "serve:liferay": "npx serve ./build",
+	  "mock": "json-server -p 3333 -d 200 ./mock/db.json --routes ./mock/routes.json"
 	},
 	"eslintConfig": {
-		"extends": [
-			"react-app",
-			"react-app/jest"
-		]
+	  "extends": [
+		"react-app",
+		"react-app/jest"
+	  ]
+	},
+	"browserslist": {
+	  "production": [
+		">0.2%",
+		"not dead",
+		"not op_mini all"
+	  ],
+	  "development": [
+		"last 1 chrome version",
+		"last 1 firefox version",
+		"last 1 safari version"
+	  ]
 	},
 	"jest": {
-		"collectCoverageFrom": [
-			"src/**/*.{js,jsx,ts,tsx}",
-			"!src/**/*.d.ts"
-		],
-		"moduleFileExtensions": [
-			"web.js",
-			"js",
-			"web.ts",
-			"ts",
-			"web.tsx",
-			"tsx",
-			"json",
-			"web.jsx",
-			"jsx",
-			"node"
-		],
-		"moduleNameMapper": {
-			"^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy",
-			"^react-native$": "react-native-web"
-		},
-		"modulePaths": [],
-		"resetMocks": true,
-		"roots": [
-			"<rootDir>/src"
-		],
-		"setupFiles": [
-			"react-app-polyfill/jsdom"
-		],
-		"setupFilesAfterEnv": [],
-		"testEnvironment": "jsdom",
-		"testMatch": [
-			"<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
-			"<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}"
-		],
-		"testRunner": "/home/giuseppe.davanzo/Documents/Repos/rl-d2c-web/node_modules/jest-circus/runner.js",
-		"transform": {
-			"^(?!.*\\.(js|jsx|mjs|cjs|ts|tsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js",
-			"^.+\\.(js|jsx|mjs|cjs|ts|tsx)$": "<rootDir>/config/jest/babelTransform.js",
-			"^.+\\.css$": "<rootDir>/config/jest/cssTransform.js"
-		},
-		"transformIgnorePatterns": [
-			"[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$",
-			"^.+\\.module\\.(css|sass|scss)$"
-		],
-		"watchPlugins": [
-			"jest-watch-typeahead/filename",
-			"jest-watch-typeahead/testname"
-		]
+	  "roots": [
+		"<rootDir>/src"
+	  ],
+	  "collectCoverageFrom": [
+		"src/**/*.{js,jsx,ts,tsx}",
+		"!src/**/*.d.ts"
+	  ],
+	  "setupFiles": [
+		"react-app-polyfill/jsdom"
+	  ],
+	  "setupFilesAfterEnv": [],
+	  "testMatch": [
+		"<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
+		"<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}"
+	  ],
+	  "testEnvironment": "jsdom",
+	  "testRunner": "/home/giuseppe.davanzo/Documents/Repos/rl-d2c-web/node_modules/jest-circus/runner.js",
+	  "transform": {
+		"^.+\\.(js|jsx|mjs|cjs|ts|tsx)$": "<rootDir>/config/jest/babelTransform.js",
+		"^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
+		"^(?!.*\\.(js|jsx|mjs|cjs|ts|tsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
+	  },
+	  "transformIgnorePatterns": [
+		"[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$",
+		"^.+\\.module\\.(css|sass|scss)$"
+	  ],
+	  "modulePaths": [],
+	  "moduleNameMapper": {
+		"^react-native$": "react-native-web",
+		"^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy"
+	  },
+	  "moduleFileExtensions": [
+		"web.js",
+		"js",
+		"web.ts",
+		"ts",
+		"web.tsx",
+		"tsx",
+		"json",
+		"web.jsx",
+		"jsx",
+		"node"
+	  ],
+	  "watchPlugins": [
+		"jest-watch-typeahead/filename",
+		"jest-watch-typeahead/testname"
+	  ],
+	  "resetMocks": true
 	},
-	"name": "d2c.web",
-	"private": true,
-	"scripts": {
-		"build": "node scripts/build.js",
-		"build:liferay": "yarn build && ./setup-liferay.sh",
-		"mock": "json-server -p 3333 -d 200 ./mock/db.json --routes ./mock/routes.json",
-		"serve:liferay": "npx serve ./build",
-		"start": "node scripts/start.js"
+	"babel": {
+	  "presets": [
+		"react-app"
+	  ]
 	},
-	"version": "0.1.0"
-}
+	"devDependencies": {
+	  "json-server": "^0.16.3",
+	  "sass-to-string": "^1.5.1"
+	}
+  }


### PR DESCRIPTION
After ran Source Format on **raylife-d2c-web**, the source formatter downgraded React version from 17.0.2 to 16.12 and broke up everything in our application.

In this PR, I'm reverting this.