### PR TITLE
LPS-146479 [CP 2.0] Create graphql request for Liferay staff to view all projects

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/services/liferay/graphql/queries.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/services/liferay/graphql/queries.js
@@ -301,6 +301,17 @@ export const getListTypeDefinitions = gql`
 	}
 `;
 
+export const getAccounts = gql`
+	query getAccounts {
+		accounts {
+			items {
+				name
+				externalReferenceCode
+			}
+		}
+	}
+`;
+
 export const getUserAccount = gql`
 	query getUserAccount($id: Long!) {
 		userAccount(userAccountId: $id) {
@@ -312,6 +323,9 @@ export const getUserAccount = gql`
 					id
 					name
 				}
+			}
+			roleBriefs {
+				name
 			}
 			externalReferenceCode
 			id

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/services/liferay/graphql/queries.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/services/liferay/graphql/queries.js
@@ -305,8 +305,8 @@ export const getAccounts = gql`
 	query getAccounts {
 		accounts {
 			items {
-				name
 				externalReferenceCode
+				name
 			}
 		}
 	}
@@ -324,13 +324,13 @@ export const getUserAccount = gql`
 					name
 				}
 			}
-			roleBriefs {
-				name
-			}
 			externalReferenceCode
 			id
 			image
 			name
+			roleBriefs {
+				name
+			}
 		}
 	}
 `;

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/Home/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/Home/index.js
@@ -76,7 +76,8 @@ const Home = ({userAccount}) => {
 					accounts = dataAccounts?.accounts?.items;
 					accountKeysFilter = getKoroneikiFilter(accounts);
 				}
-			} else if (userAccount?.accountBriefs?.length) {
+			}
+			else if (userAccount?.accountBriefs?.length) {
 				accounts = userAccount?.accountBriefs;
 				accountKeysFilter = getKoroneikiFilter(accounts);
 			}

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/Home/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/Home/index.js
@@ -12,7 +12,10 @@
 import classNames from 'classnames';
 import {useEffect, useState} from 'react';
 import client from '../../../../apolloClient';
-import {getKoroneikiAccounts} from '../../../../common/services/liferay/graphql/queries';
+import {
+	getAccounts,
+	getKoroneikiAccounts,
+} from '../../../../common/services/liferay/graphql/queries';
 import {SEARCH_PARAMS_KEYS} from '../../../../common/utils/constants';
 import getLiferaySiteName from '../../../../common/utils/getLiferaySiteName';
 import ProjectCard from '../../components/ProjectCard';
@@ -35,76 +38,95 @@ const getStatus = (slaCurrent, slaFuture) => {
 	return STATUS_TAG_TYPES.expired;
 };
 
+const getKoroneikiFilter = (accounts) => {
+	return accounts
+		?.map(
+			({externalReferenceCode}, index, {length: totalAccounts}) =>
+				`accountKey eq '${externalReferenceCode}'${
+					index + 1 < totalAccounts ? ' or' : ''
+				}`
+		)
+		.join(' ');
+};
+
 const Home = ({userAccount}) => {
 	const [keyword, setKeyword] = useState('');
 	const [projects, setProjects] = useState([]);
 	const [isLoading, setIsLoading] = useState(true);
 
 	useEffect(() => {
-		const getProjects = async (accountKeysFilter, accountBriefs) => {
-			const {data} = await client.query({
-				query: getKoroneikiAccounts,
-				variables: {
-					filter: accountKeysFilter,
-				},
-			});
+		const getProjects = async (userAccount) => {
+			const hasRoleBriefAdministrator = userAccount?.roleBriefs?.some(
+				(role) => role.name === 'Administrator'
+			);
 
-			if (data) {
-				setProjects(
-					data.c?.koroneikiAccounts?.items.map(
-						({
-							accountKey,
-							code,
-							liferayContactEmailAddress,
-							liferayContactName,
-							liferayContactRole,
-							region,
-							slaCurrent,
-							slaCurrentEndDate,
-							slaFuture,
-						}) => ({
-							accountKey,
-							code,
-							contact: {
-								emailAddress: liferayContactEmailAddress,
-								name: liferayContactName,
-								role: liferayContactRole,
-							},
-							region,
-							sla: {
-								current: slaCurrent,
-								currentEndDate: slaCurrentEndDate,
-								future: slaFuture,
-							},
-							status: getStatus(slaCurrent, slaFuture),
-							title: accountBriefs.find(
-								({externalReferenceCode}) =>
-									externalReferenceCode === accountKey
-							)?.name,
-						})
-					) || []
-				);
+			let accountKeysFilter;
+			let accounts = [];
+
+			if (hasRoleBriefAdministrator) {
+				const {data: dataAccounts} = await client.query({
+					query: getAccounts,
+				});
+
+				if (dataAccounts) {
+					accounts = dataAccounts?.accounts?.items;
+					accountKeysFilter = getKoroneikiFilter(accounts);
+				}
+			} else if (userAccount?.accountBriefs?.length) {
+				accounts = userAccount?.accountBriefs;
+				accountKeysFilter = getKoroneikiFilter(accounts);
 			}
 
-			setIsLoading(false);
+			if (accounts.length) {
+				const {data} = await client.query({
+					query: getKoroneikiAccounts,
+					variables: {
+						filter: accountKeysFilter,
+					},
+				});
+
+				if (data) {
+					setProjects(
+						data.c?.koroneikiAccounts?.items.map(
+							({
+								accountKey,
+								code,
+								liferayContactEmailAddress,
+								liferayContactName,
+								liferayContactRole,
+								region,
+								slaCurrent,
+								slaCurrentEndDate,
+								slaFuture,
+							}) => ({
+								accountKey,
+								code,
+								contact: {
+									emailAddress: liferayContactEmailAddress,
+									name: liferayContactName,
+									role: liferayContactRole,
+								},
+								region,
+								sla: {
+									current: slaCurrent,
+									currentEndDate: slaCurrentEndDate,
+									future: slaFuture,
+								},
+								status: getStatus(slaCurrent, slaFuture),
+								title: accounts.find(
+									({externalReferenceCode}) =>
+										externalReferenceCode === accountKey
+								)?.name,
+							})
+						) || []
+					);
+				}
+
+				setIsLoading(false);
+			}
 		};
 
-		if (userAccount.accountBriefs.length) {
-			const accountKeys = userAccount.accountBriefs
-				?.map(
-					(
-						{externalReferenceCode},
-						index,
-						{length: totalAccountBriefs}
-					) =>
-						`accountKey eq '${externalReferenceCode}'${
-							index + 1 < totalAccountBriefs ? ' or' : ''
-						}`
-				)
-				.join(' ');
-
-			getProjects(accountKeys, userAccount.accountBriefs);
-		}
+		getProjects(userAccount);
 	}, [userAccount]);
 
 	const nextPage = (project) => {

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/Home/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/Home/index.js
@@ -72,7 +72,8 @@ const Home = ({userAccount}) => {
 					accounts = dataAccounts?.accounts?.items;
 					accountKeysFilter = getKoroneikiFilter(accounts);
 				}
-			} else if (userAccount?.accountBriefs?.length) {
+			}
+			else if (userAccount?.accountBriefs?.length) {
 				accounts = userAccount?.accountBriefs;
 				accountKeysFilter = getKoroneikiFilter(accounts);
 			}

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/Home/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/Home/index.js
@@ -39,14 +39,13 @@ const getStatus = (slaCurrent, slaFuture) => {
 };
 
 const getKoroneikiFilter = (accounts) => {
-	return accounts
-		?.map(
-			({externalReferenceCode}, index, {length: totalAccounts}) =>
-				`accountKey eq '${externalReferenceCode}'${
-					index + 1 < totalAccounts ? ' or' : ''
-				}`
-		)
-		.join(' ');
+	return accounts?.reduce(
+		(acc, {externalReferenceCode}, index, {length: totalAccounts}) =>
+			`${acc}accountKey eq '${externalReferenceCode}'${
+				index + 1 < totalAccounts ? ' or ' : ''
+			}`,
+		''
+	);
 };
 
 const Home = ({userAccount}) => {
@@ -72,8 +71,7 @@ const Home = ({userAccount}) => {
 					accounts = dataAccounts?.accounts?.items;
 					accountKeysFilter = getKoroneikiFilter(accounts);
 				}
-			}
-			else if (userAccount?.accountBriefs?.length) {
+			} else if (userAccount?.accountBriefs?.length) {
 				accounts = userAccount?.accountBriefs;
 				accountKeysFilter = getKoroneikiFilter(accounts);
 			}

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/Home/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/Home/index.js
@@ -40,8 +40,13 @@ const getStatus = (slaCurrent, slaFuture) => {
 
 const getKoroneikiFilter = (accounts) => {
 	return accounts?.reduce(
-		(acc, {externalReferenceCode}, index, {length: totalAccounts}) =>
-			`${acc}accountKey eq '${externalReferenceCode}'${
+		(
+			koroneikiFilterAccumulator,
+			{externalReferenceCode},
+			index,
+			{length: totalAccounts}
+		) =>
+			`${koroneikiFilterAccumulator}accountKey eq '${externalReferenceCode}'${
 				index + 1 < totalAccounts ? ' or ' : ''
 			}`,
 		''


### PR DESCRIPTION
# How it was developed?
   - I used Graphql to query all the projects and check if the user is an administrator.

**Query projects**
![query_projetos](https://user-images.githubusercontent.com/93679278/152061835-7081d8b2-6f3a-4f02-a834-55e7712a5941.png)
**Query administrator** 
![query_administrator](https://user-images.githubusercontent.com/93679278/152062041-7f0c9030-2f86-47a0-a76e-ec243d310392.png)

# What has been affected by the development?
   - I implemented a roleBriefs field in the getUserAccount query.
   
  ![queries_lps](https://user-images.githubusercontent.com/93679278/152056269-018275dc-1422-4ce3-940a-925b4a667300.png)


# Test Plan
  **Test 1**
  - Log in as an administrator user
  - Add 2 or more projects
  - Associate fewer projects than the total number of projects
  - Go to the home page, make sure the user is viewing all projects, regardless of which one is associated
 
**Test 2**
  - Log in with a user that is not an administrator
  - Add 1 or more projects
  - Associate projects to the user
  - Go to the home page, make sure the user is viewing the projects he is associated with
   