### PR TITLE
LPS-147081 LPS-147082 [CP 2.0] Adding download developer key alert and adjusting license downloaded file name

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/layouts/DeveloperKeysLayout/Inputs/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/layouts/DeveloperKeysLayout/Inputs/index.js
@@ -24,10 +24,11 @@ import {
 	STATUS_CODE,
 } from '../../../utils/constants';
 
-const DevelopersKeysInputs = ({
+const DeveloperKeysInputs = ({
 	accountKey,
 	downloadTextHelper,
 	dxpVersion,
+	projectName,
 	sessionId,
 }) => {
 	const {
@@ -75,7 +76,14 @@ const DevelopersKeysInputs = ({
 			const extensionFile = EXTENSION_FILE_TYPES[contentType] || '.txt';
 			const licenseBlob = await license.blob();
 
-			downloadFromBlob(licenseBlob, `license${extensionFile}`);
+			const projectFileName = projectName
+				.replaceAll(' ', '')
+				.toLowerCase();
+
+			downloadFromBlob(
+				licenseBlob,
+				`activation-key-dxpdevelopment-${selectedVersion}-${projectFileName}${extensionFile}`
+			);
 
 			return;
 		}
@@ -144,4 +152,4 @@ const DevelopersKeysInputs = ({
 	);
 };
 
-export default DevelopersKeysInputs;
+export default DeveloperKeysInputs;

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/layouts/DeveloperKeysLayout/Inputs/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/layouts/DeveloperKeysLayout/Inputs/index.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayAlert from '@clayui/alert';
 import {ClaySelect} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import {useEffect, useState} from 'react';
@@ -19,10 +20,17 @@ import {getListTypeDefinitions} from '../../../../../common/services/liferay/gra
 import {getDevelopmentLicenseKey} from '../../../../../common/services/liferay/rest/raysource/LicenseKeys';
 import downloadFromBlob from '../../../../../common/utils/downloadFromBlob';
 import {
+	ALERT_DOWNLOAD_TYPE,
+	AUTO_CLOSE_DOWNLOAD_ALERT_TIME,
 	EXTENSION_FILE_TYPES,
 	LIST_TYPES,
 	STATUS_CODE,
 } from '../../../utils/constants';
+
+const ALERT_DEVELOPER_KEYS_DOWNLOAD_TEXT = {
+	[ALERT_DOWNLOAD_TYPE.danger]: 'Unable to download key, please try again.',
+	[ALERT_DOWNLOAD_TYPE.success]: 'Developer Key was downloaded successfully.',
+};
 
 const DeveloperKeysInputs = ({
 	accountKey,
@@ -37,6 +45,10 @@ const DeveloperKeysInputs = ({
 	} = useApplicationProvider();
 	const [dxpVersions, setDxpVersions] = useState([]);
 	const [selectedVersion, setSelectedVersion] = useState(dxpVersion);
+	const [
+		developerKeysDownloadStatus,
+		setDeveloperKeysDownloadStatus,
+	] = useState('');
 
 	useEffect(() => {
 		const fetchListTypeDefinitions = async () => {
@@ -63,7 +75,7 @@ const DeveloperKeysInputs = ({
 		fetchListTypeDefinitions();
 	}, [dxpVersion]);
 
-	const handleClick = async () => {
+	const developerKeyDownload = async () => {
 		const license = await getDevelopmentLicenseKey(
 			accountKey,
 			licenseKeyDownloadURL,
@@ -76,17 +88,19 @@ const DeveloperKeysInputs = ({
 			const extensionFile = EXTENSION_FILE_TYPES[contentType] || '.txt';
 			const licenseBlob = await license.blob();
 
+			setDeveloperKeysDownloadStatus(ALERT_DOWNLOAD_TYPE.success);
+
 			const projectFileName = projectName
 				.replaceAll(' ', '')
 				.toLowerCase();
 
-			downloadFromBlob(
+			return downloadFromBlob(
 				licenseBlob,
 				`activation-key-dxpdevelopment-${selectedVersion}-${projectFileName}${extensionFile}`
 			);
-
-			return;
 		}
+
+		setDeveloperKeysDownloadStatus(ALERT_DOWNLOAD_TYPE.danger);
 	};
 
 	return (
@@ -126,7 +140,7 @@ const DeveloperKeysInputs = ({
 
 				<Button
 					className="btn btn-outline-primary cp-developer-keys-button py-1"
-					onClick={handleClick}
+					onClick={developerKeyDownload}
 					prependIcon="download"
 					type="button"
 				>
@@ -148,6 +162,29 @@ const DeveloperKeysInputs = ({
 					</u>
 				</a>
 			</p>
+
+			{developerKeysDownloadStatus && (
+				<ClayAlert.ToastContainer>
+					<ClayAlert
+						autoClose={
+							AUTO_CLOSE_DOWNLOAD_ALERT_TIME[
+								developerKeysDownloadStatus
+							]
+						}
+						className="cp-activation-key-download-alert px-4 py-3 text-paragraph"
+						displayType={
+							ALERT_DOWNLOAD_TYPE[developerKeysDownloadStatus]
+						}
+						onClose={() => setDeveloperKeysDownloadStatus('')}
+					>
+						{
+							ALERT_DEVELOPER_KEYS_DOWNLOAD_TEXT[
+								developerKeysDownloadStatus
+							]
+						}
+					</ClayAlert>
+				</ClayAlert.ToastContainer>
+			)}
 		</div>
 	);
 };

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/DXP/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/DXP/index.js
@@ -21,6 +21,7 @@ const DXP = ({project, sessionId}) => {
 					accountKey={project.accountKey}
 					downloadTextHelper="Select the Liferay DXP version for which you want to download a developer key."
 					dxpVersion={project.dxpVersion}
+					projectName={project.name}
 					sessionId={sessionId}
 				></DeveloperKeysLayouts.Inputs>
 			</DeveloperKeysLayouts>


### PR DESCRIPTION
**How it was developed?**

It was implemented an alert to show download status when user try download an developer key.
If download goes successfully it will show a success alert.
If download fails it will show a danger alert.
The download file name is specific to selected DXP version and project name

**Downloaded file and alert:**

![image](https://user-images.githubusercontent.com/77743987/153234594-97b5fa05-cd50-4a87-acf2-9b008c394418.png)

**What has been affected by the development ?**
DeveloperKeysInputs has one more state and an rendering verification to show or no an alert.
Nothing was added on data mock up.

### Test Plan
1. Enter in a project with DXP subscription.
2. Click on "Product Activation" on side menu, and click in DXP or DXP Cloud.
3. On Developer Keys session, select a version and click in download button.
4. This should download the file.
5. If download works fine, see if a success alert appears, and license file starts download.
6. If not, see if a fail alert appears.

PS: Make sure that you're authenticated with Okta sign in. (User Garrett)