### PR TITLE
LPS-146892 LPS-146893 LPS-147000 LPS-147141 [CP 2.0] Deactivate key - DXP

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/services/liferay/rest/raysource/LicenseKeys.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/services/liferay/rest/raysource/LicenseKeys.js
@@ -128,3 +128,23 @@ export async function getExportedLicenseKeys(
 
 	return response;
 }
+
+export async function putDeactivateKeys(
+	licenseKeyDownloadURL,
+	licenseKeyIds,
+	sessionId
+) {
+	// eslint-disable-next-line @liferay/portal/no-global-fetch
+	const response = await fetch(
+		`${licenseKeyDownloadURL}/license-keys/activate?${licenseKeyIds}`,
+
+		{
+			headers: {
+				'Okta-Session-ID': sessionId,
+			},
+			method: 'PUT',
+		}
+	);
+
+	return response;
+}

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/containers/DXPActivationKeysTable/Deactivate/Modal/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/containers/DXPActivationKeysTable/Deactivate/Modal/index.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import ClayIcon from '@clayui/icon';
+import ClayModal from '@clayui/modal';
+import classNames from 'classnames';
+import Button from '../../../../../../common/components/Button';
+import {ALERT_DOWNLOAD_TYPE} from '../../../../utils/constants';
+
+const DeactivateKeysModal = ({
+	deactivateKeysConfirm,
+	deactivateKeysStatus,
+	isDeactivating,
+	observer,
+	onClose,
+}) => {
+	return (
+		<ClayModal center observer={observer}>
+			<div className="pt-4 px-4">
+				<div className="flex-row mb-1">
+					<h2 className="text-neutral-10">
+						Confirm Deactivation Terms
+					</h2>
+
+					<p className="mb-6 mt-5 text-neutral-10">
+						I certify that the instance(s) activated with the
+						selected activation key(s) has/have been shut down and
+						that there is no Liferay software installed, deployed,
+						used or executed that is activated with the selected
+						activation key(s).
+					</p>
+				</div>
+
+				<div className="d-flex justify-content-end my-4">
+					<Button displayType="secondary" onClick={onClose}>
+						Cancel
+					</Button>
+
+					<Button
+						className={classNames('bg-danger d-flex ml-2', {
+							'cp-deactivate-loading': isDeactivating,
+						})}
+						onClick={deactivateKeysConfirm}
+					>
+						{isDeactivating
+							? 'Deactivating......'
+							: 'Confirm & Deactivate Keys'}
+					</Button>
+				</div>
+			</div>
+
+			{!isDeactivating &&
+				deactivateKeysStatus === ALERT_DOWNLOAD_TYPE.danger && (
+					<div className="allign cp-error-alert d-flex px-4 py-3">
+						<ClayIcon
+							className="mr-2 mt-1 text-danger"
+							symbol="info-circle"
+						/>
+
+						<p className="m-0 text-danger text-paragraph">
+							There was an unexpected error while attempting to
+							deactivate keys. Please try again in a few moments
+						</p>
+					</div>
+				)}
+		</ClayModal>
+	);
+};
+
+export default DeactivateKeysModal;

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/containers/DXPActivationKeysTable/Deactivate/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/containers/DXPActivationKeysTable/Deactivate/index.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import ClayAlert from '@clayui/alert';
+import {Button as ClayButton} from '@clayui/core';
+import {useModal} from '@clayui/modal';
+import {useState} from 'react';
+import {useApplicationProvider} from '../../../../../common/context/AppPropertiesProvider';
+import {putDeactivateKeys} from '../../../../../common/services/liferay/rest/raysource/LicenseKeys';
+import {ALERT_DOWNLOAD_TYPE, STATUS_CODE} from '../../../utils/constants';
+import DeactivateKeysModal from './Modal';
+
+const DeactivateButton = ({selectedKeys, sessionId}) => {
+	const {licenseKeyDownloadURL} = useApplicationProvider();
+	const [deactivateKeysStatus, setDeactivateKeysStatus] = useState('');
+	const [isDeactivating, setIsDeactivating] = useState(false);
+	const [isVisibleModal, setIsVisibleModal] = useState(false);
+	const {observer, onClose} = useModal({
+		onClose: () => {
+			setIsVisibleModal(false);
+			setDeactivateKeysStatus('');
+		},
+	});
+
+	const deactivateKeysConfirm = async () => {
+		setIsDeactivating(true);
+		const licenseKeyIds = selectedKeys
+			.map((selectedKey) => `licenseKeyIds=${selectedKey}`)
+			.join('&');
+
+		const response = await putDeactivateKeys(
+			licenseKeyDownloadURL,
+			licenseKeyIds,
+			sessionId
+		);
+
+		if (response.status === STATUS_CODE.sucess) {
+			setIsDeactivating(false);
+			setIsVisibleModal(false);
+
+			return setDeactivateKeysStatus(ALERT_DOWNLOAD_TYPE.success);
+		}
+
+		setIsDeactivating(false);
+		setDeactivateKeysStatus(ALERT_DOWNLOAD_TYPE.danger);
+	};
+
+	return (
+		<>
+			{deactivateKeysStatus === ALERT_DOWNLOAD_TYPE.success && (
+				<ClayAlert.ToastContainer>
+					<ClayAlert
+						autoClose={2000}
+						className="cp-activation-key-download-alert px-4 py-3 text-paragraph"
+						displayType={ALERT_DOWNLOAD_TYPE[deactivateKeysStatus]}
+						onClose={() => setDeactivateKeysStatus('')}
+					>
+						Activation Key(s) were deactivated successfully.
+					</ClayAlert>
+				</ClayAlert.ToastContainer>
+			)}
+			{isVisibleModal && (
+				<DeactivateKeysModal
+					deactivateKeysConfirm={deactivateKeysConfirm}
+					deactivateKeysStatus={deactivateKeysStatus}
+					isDeactivating={isDeactivating}
+					observer={observer}
+					onClose={onClose}
+				/>
+			)}
+
+			<ClayButton
+				className="btn-outline-danger cp-deactivate-button mx-2 px-3 py-2"
+				onClick={() => setIsVisibleModal(true)}
+			>
+				Deactivate
+			</ClayButton>
+		</>
+	);
+};
+
+export default DeactivateButton;

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/containers/DXPActivationKeysTable/Deactivate/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/containers/DXPActivationKeysTable/Deactivate/index.js
@@ -15,10 +15,14 @@ import {useModal} from '@clayui/modal';
 import {useState} from 'react';
 import {useApplicationProvider} from '../../../../../common/context/AppPropertiesProvider';
 import {putDeactivateKeys} from '../../../../../common/services/liferay/rest/raysource/LicenseKeys';
-import {ALERT_DOWNLOAD_TYPE, STATUS_CODE} from '../../../utils/constants';
+import {
+	ALERT_DOWNLOAD_TYPE,
+	AUTO_CLOSE_DOWNLOAD_ALERT_TIME,
+	STATUS_CODE,
+} from '../../../utils/constants';
 import DeactivateKeysModal from './Modal';
 
-const DeactivateButton = ({selectedKeys, sessionId}) => {
+const DeactivateButton = ({selectedKeys, sessionId, setActivationKeys}) => {
 	const {licenseKeyDownloadURL} = useApplicationProvider();
 	const [deactivateKeysStatus, setDeactivateKeysStatus] = useState('');
 	const [isDeactivating, setIsDeactivating] = useState(false);
@@ -45,6 +49,11 @@ const DeactivateButton = ({selectedKeys, sessionId}) => {
 		if (response.status === STATUS_CODE.sucess) {
 			setIsDeactivating(false);
 			setIsVisibleModal(false);
+			setActivationKeys((previousActivationKeys) =>
+				previousActivationKeys.filter(
+					(activationKeys) => !selectedKeys.includes(activationKeys)
+				)
+			);
 
 			return setDeactivateKeysStatus(ALERT_DOWNLOAD_TYPE.success);
 		}
@@ -58,7 +67,7 @@ const DeactivateButton = ({selectedKeys, sessionId}) => {
 			{deactivateKeysStatus === ALERT_DOWNLOAD_TYPE.success && (
 				<ClayAlert.ToastContainer>
 					<ClayAlert
-						autoClose={2000}
+						autoClose={AUTO_CLOSE_DOWNLOAD_ALERT_TIME.success}
 						className="cp-activation-key-download-alert px-4 py-3 text-paragraph"
 						displayType={ALERT_DOWNLOAD_TYPE[deactivateKeysStatus]}
 						onClose={() => setDeactivateKeysStatus('')}

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/containers/DXPActivationKeysTable/Header/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/containers/DXPActivationKeysTable/Header/index.js
@@ -16,6 +16,7 @@ import {useMemo, useState} from 'react';
 import {Button, ButtonDropDown} from '../../../../../common/components';
 import {ALERT_DOWNLOAD_TYPE} from '../../../utils/constants/alertDownloadType';
 import {AUTO_CLOSE_DOWNLOAD_ALERT_TIME} from '../../../utils/constants/autoCloseDownloadAlertTime';
+import DeactivateButton from '../Deactivate';
 import {DOWNLOADABLE_LICENSE_KEYS} from '../utils/constants';
 import {ALERT_ACTIVATION_AGGREGATED_KEYS_DOWNLOAD_TEXT} from '../utils/constants/alertAggregateKeysDownloadText';
 import {getActivationKeyDownload} from '../utils/getActivationKeyDownload';
@@ -28,6 +29,7 @@ const DXPActivationKeysTableHeader = ({
 	licenseKeyDownloadURL,
 	selectedKeys,
 	sessionId,
+	setActivationKeys,
 }) => {
 	const [
 		activationKeysDownloadStatus,
@@ -129,23 +131,25 @@ const DXPActivationKeysTableHeader = ({
 	return (
 		<div>
 			<div className="align-items-center bg-neutral-1 d-flex mb-2 p-3 rounded">
-				{!!selectedKeys.length && (
-					<>
-						<p className="font-weight-semi-bold m-0 ml-auto text-neutral-10">
-							{`${selectedKeys.length} Keys Selected`}
-						</p>
-
-						<Button className="btn-outline-danger cp-deactivate-button mx-2">
-							Deactivate
-						</Button>
-					</>
-				)}
-
 				<div
-					className={classNames({
+					className={classNames('align-items-center d-flex', {
 						'ml-auto': !selectedKeys.length,
 					})}
 				>
+					{!!selectedKeys.length && (
+						<>
+							<p className="font-weight-semi-bold m-0 ml-auto text-neutral-10">
+								{`${selectedKeys.length} Keys Selected`}
+							</p>
+
+							<DeactivateButton
+								selectedKeys={selectedKeys}
+								sessionId={sessionId}
+								setActivationKeys={setActivationKeys}
+							/>
+						</>
+					)}
+
 					{getCurrentButton()}
 				</div>
 			</div>

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/containers/DXPActivationKeysTable/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/containers/DXPActivationKeysTable/index.js
@@ -185,6 +185,7 @@ const DXPActivationKeysTable = ({project, sessionId}) => {
 						licenseKeyDownloadURL={licenseKeyDownloadURL}
 						selectedKeys={activationKeysChecked}
 						sessionId={sessionId}
+						setActivationKeys={setActivationKeys}
 					/>
 				</div>
 

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/styles/components/_activation-keys.scss
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/styles/components/_activation-keys.scss
@@ -16,3 +16,16 @@
 	bottom: 2rem;
 	left: 2rem;
 }
+
+.cp-error-alert {
+	background-color: var(--color-state-error-lighten-1);
+
+	svg {
+		height: 1.5rem;
+		width: 1.5rem;
+	}
+}
+
+.cp-deactivate-loading {
+	opacity: 0.5;
+}


### PR DESCRIPTION
**How it was developed?**

It was implemented a button to deactivate keys.
The deactivate button should appears only with some key is selected.
When click in "Deactvate", a modal should appears to confirm deactivation.
If deactivation goes successfully, the modal closes and a success alert is showed.
The deactivated keys shouldn't no longer be on the list.
If deactivation fails, it will show a danger alert on the modal.


**What has been affected by the development ?**
DXPActivationKeysTable send the set function Activations Keys to the button for filter the keys if some keys were deactivated.
The table will re-render.

Nothing was added on data mock up.

### Test Plan
1. Enter in a project with DXP subscription.
2. Click on "Product Activation" on side menu, and click in DXP.
3. On Activation Keys session, select a key on the table and click in deactivate button.
4. A modal should be shown.
5. Confirm deactivation.
6. If deactivation works fine, the modal should close and a success alert appears, the key will no longer be listed on table.
7. If not work, a fail alert appears on the modal.

PS: Make sure that you're authenticated with Okta sign in. (User Garrett)