### PR TITLE
LPS 145463 - Automate Product Display Page assignment in site initializer

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/commerce-channel.default-product-display-page.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/commerce-channel.default-product-display-page.json
@@ -1,0 +1,4 @@
+{
+	"friendlyURL": "/test-public-layout",
+	"privateLayout": false
+}

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -25,6 +25,7 @@ import com.liferay.commerce.inventory.model.CommerceInventoryWarehouse;
 import com.liferay.commerce.inventory.service.CommerceInventoryWarehouseLocalService;
 import com.liferay.commerce.notification.model.CommerceNotificationTemplate;
 import com.liferay.commerce.notification.service.CommerceNotificationTemplateLocalService;
+import com.liferay.commerce.product.constants.CPConstants;
 import com.liferay.commerce.product.model.CPAttachmentFileEntry;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPDefinitionOptionRel;
@@ -86,6 +87,10 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
+import com.liferay.portal.kernel.settings.ModifiableSettings;
+import com.liferay.portal.kernel.settings.Settings;
+import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -404,6 +409,7 @@ public class BundleSiteInitializerTest {
 		Assert.assertEquals("Test Commerce Channel", commerceChannel.getName());
 		Assert.assertEquals("site", commerceChannel.getType());
 
+		_assertDefaultProductDisplayPage(commerceChannel, group);
 		_assertCommerceNotificationTemplate(commerceChannel, group);
 	}
 
@@ -552,6 +558,31 @@ public class BundleSiteInitializerTest {
 
 		Assert.assertNotNull(ddmTemplate);
 		Assert.assertEquals("${aField.getData()}", ddmTemplate.getScript());
+	}
+
+	private void _assertDefaultProductDisplayPage(
+			CommerceChannel commerceChannel, Group group)
+		throws Exception {
+
+		Settings settings = _settingsFactory.getSettings(
+			new GroupServiceSettingsLocator(
+				commerceChannel.getGroupId(),
+				CPConstants.RESOURCE_NAME_CP_DISPLAY_LAYOUT));
+
+		ModifiableSettings modifiableSettings =
+			settings.getModifiableSettings();
+
+		String productLayoutUuid = modifiableSettings.getValue(
+			"productLayoutUuid", null);
+
+		Assert.assertNotNull(productLayoutUuid);
+
+		List<Layout> publicLayouts = _layoutLocalService.getLayouts(
+			group.getGroupId(), false);
+
+		Layout publicLayout = publicLayouts.get(0);
+
+		Assert.assertEquals(productLayoutUuid, publicLayout.getUuid());
 	}
 
 	private void _assertDLFileEntry(Group group) throws Exception {
@@ -1186,6 +1217,9 @@ public class BundleSiteInitializerTest {
 
 	@Inject
 	private ServletContext _servletContext;
+
+	@Inject
+	private SettingsFactory _settingsFactory;
 
 	@Inject
 	private SiteInitializerRegistry _siteInitializerRegistry;

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -22,6 +22,7 @@ import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.commerce.account.constants.CommerceAccountConstants;
 import com.liferay.commerce.inventory.model.CommerceInventoryWarehouse;
+import com.liferay.commerce.product.constants.CPConstants;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.model.CommerceChannel;
@@ -701,6 +702,11 @@ public class BundleSiteInitializer implements SiteInitializer {
 
 		channel = channelResource.postChannel(channel);
 
+		_addDefaultProductDisplayPage(
+			channel,
+			StringUtil.replaceLast(
+				resourcePath, ".json", ".default-product-display-page.json"),
+			serviceContext);
 		_addModelResourcePermissions(
 			CommerceChannel.class.getName(), String.valueOf(channel.getId()),
 			StringUtil.replaceLast(
@@ -1063,6 +1069,50 @@ public class BundleSiteInitializer implements SiteInitializer {
 				TemplateConstants.LANG_TYPE_FTL, _read("ddm-template.ftl", url),
 				false, false, null, null, serviceContext);
 		}
+	}
+
+	private void _addDefaultProductDisplayPage(
+			Channel channel, String resourcePath, ServiceContext serviceContext)
+		throws Exception {
+
+		String json = _read(resourcePath);
+
+		if (json == null) {
+			return;
+		}
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(json);
+
+		Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+			serviceContext.getScopeGroupId(),
+			jsonObject.getBoolean("privateLayout"),
+			jsonObject.getString("friendlyURL"));
+
+		if (layout == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to create a default product display page from " +
+						"JSON: " + json);
+			}
+
+			return;
+		}
+
+		CommerceChannel commerceChannel =
+			_commerceReferencesHolder.commerceChannelLocalService.
+				getCommerceChannel(channel.getId());
+
+		Settings settings = _settingsFactory.getSettings(
+			new GroupServiceSettingsLocator(
+				commerceChannel.getGroupId(),
+				CPConstants.RESOURCE_NAME_CP_DISPLAY_LAYOUT));
+
+		ModifiableSettings modifiableSettings =
+			settings.getModifiableSettings();
+
+		modifiableSettings.setValue("productLayoutUuid", layout.getUuid());
+
+		modifiableSettings.store();
 	}
 
 	private Long _addDocumentFolder(

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/commerce-channel.default-product-display-page.json
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/commerce-channel.default-product-display-page.json
@@ -1,0 +1,4 @@
+{
+	"friendlyURL": "/starter-kit-detail",
+	"privateLayout": false
+}


### PR DESCRIPTION
Dear Team, the idea of the PR is to automate the product display page in the commerce channel. Please let me know what you think and if it would be better to use other namings. I used resource model resource permission naming as a base (prefixed with commerce channel).

Thanks as always! 