### PR TITLE
LPS 145463 - Automate Product Display Page assignment in site initializer

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/commerce-channel.default-product-display-page.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/commerce-channel.default-product-display-page.json
@@ -1,0 +1,4 @@
+{
+	"friendlyURL": "/test-public-layout",
+	"privateLayout": false
+}

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -25,6 +25,7 @@ import com.liferay.commerce.inventory.model.CommerceInventoryWarehouse;
 import com.liferay.commerce.inventory.service.CommerceInventoryWarehouseLocalService;
 import com.liferay.commerce.notification.model.CommerceNotificationTemplate;
 import com.liferay.commerce.notification.service.CommerceNotificationTemplateLocalService;
+import com.liferay.commerce.product.constants.CPConstants;
 import com.liferay.commerce.product.model.CPAttachmentFileEntry;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPDefinitionOptionRel;
@@ -94,6 +95,10 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
+import com.liferay.portal.kernel.settings.ModifiableSettings;
+import com.liferay.portal.kernel.settings.Settings;
+import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -415,6 +420,7 @@ public class BundleSiteInitializerTest {
 		Assert.assertEquals("Test Commerce Channel", commerceChannel.getName());
 		Assert.assertEquals("site", commerceChannel.getType());
 
+		_assertDefaultProductDisplayPage(commerceChannel, group);
 		_assertCommerceNotificationTemplate(commerceChannel, group);
 	}
 
@@ -590,6 +596,31 @@ public class BundleSiteInitializerTest {
 
 		Assert.assertNotNull(ddmTemplate);
 		Assert.assertEquals("${aField.getData()}", ddmTemplate.getScript());
+	}
+
+	private void _assertDefaultProductDisplayPage(
+			CommerceChannel commerceChannel, Group group)
+		throws Exception {
+
+		Settings settings = _settingsFactory.getSettings(
+			new GroupServiceSettingsLocator(
+				commerceChannel.getGroupId(),
+				CPConstants.RESOURCE_NAME_CP_DISPLAY_LAYOUT));
+
+		ModifiableSettings modifiableSettings =
+			settings.getModifiableSettings();
+
+		String productLayoutUuid = modifiableSettings.getValue(
+			"productLayoutUuid", null);
+
+		Assert.assertNotNull(productLayoutUuid);
+
+		List<Layout> publicLayouts = _layoutLocalService.getLayouts(
+			group.getGroupId(), false);
+
+		Layout publicLayout = publicLayouts.get(0);
+
+		Assert.assertEquals(productLayoutUuid, publicLayout.getUuid());
 	}
 
 	private void _assertDLFileEntry(Group group) throws Exception {
@@ -1291,6 +1322,9 @@ public class BundleSiteInitializerTest {
 
 	@Inject
 	private ServletContext _servletContext;
+
+	@Inject
+	private SettingsFactory _settingsFactory;
 
 	@Inject
 	private SiteInitializerRegistry _siteInitializerRegistry;

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/CommerceSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/CommerceSiteInitializer.java
@@ -24,6 +24,7 @@ import com.liferay.commerce.initializer.util.CommerceInventoryWarehousesImporter
 import com.liferay.commerce.inventory.model.CommerceInventoryWarehouse;
 import com.liferay.commerce.model.CommerceOrder;
 import com.liferay.commerce.notification.service.CommerceNotificationTemplateLocalService;
+import com.liferay.commerce.product.constants.CPConstants;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.model.CommerceChannel;
@@ -32,6 +33,7 @@ import com.liferay.commerce.product.service.CPInstanceLocalService;
 import com.liferay.commerce.product.service.CPMeasurementUnitLocalService;
 import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.CommerceChannelLocalService;
+import com.liferay.commerce.product.service.CommerceChannelService;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Catalog;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Option;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductOption;
@@ -51,6 +53,8 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
@@ -240,6 +244,11 @@ public class CommerceSiteInitializer {
 
 		channel = channelResource.postChannel(channel);
 
+		_addDefaultProductDisplayPage(
+			channel,
+			StringUtil.replaceLast(
+				resourcePath, ".json", ".default-product-display-page.json"),
+			serviceContext, servletContext);
 		_addModelResourcePermissions(
 			CommerceChannel.class.getName(), String.valueOf(channel.getId()),
 			StringUtil.replaceLast(
@@ -566,6 +575,50 @@ public class CommerceSiteInitializer {
 			commerceCatalogGroup.getGroupId(), serviceContext.getUserId());
 	}
 
+	private void _addDefaultProductDisplayPage(
+			Channel channel, String resourcePath, ServiceContext serviceContext,
+			ServletContext servletContext)
+		throws Exception {
+
+		String json = SiteInitializerUtil.read(resourcePath, servletContext);
+
+		if (json == null) {
+			return;
+		}
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(json);
+
+		Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+			serviceContext.getScopeGroupId(),
+			jsonObject.getBoolean("privateLayout"),
+			jsonObject.getString("friendlyURL"));
+
+		if (layout == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to create a default product display page from " +
+						"JSON: " + json);
+			}
+
+			return;
+		}
+
+		CommerceChannel commerceChannel =
+			_commerceChannelService.getCommerceChannel(channel.getId());
+
+		Settings settings = _settingsFactory.getSettings(
+			new GroupServiceSettingsLocator(
+				commerceChannel.getGroupId(),
+				CPConstants.RESOURCE_NAME_CP_DISPLAY_LAYOUT));
+
+		ModifiableSettings modifiableSettings =
+			settings.getModifiableSettings();
+
+		modifiableSettings.setValue("productLayoutUuid", layout.getUuid());
+
+		modifiableSettings.store();
+	}
+
 	private void _addModelResourcePermissions(
 			String className, String primKey, String resourcePath,
 			ServiceContext serviceContext, ServletContext servletContext)
@@ -670,6 +723,9 @@ public class CommerceSiteInitializer {
 	private CommerceChannelLocalService _commerceChannelLocalService;
 
 	@Reference
+	private CommerceChannelService _commerceChannelService;
+
+	@Reference
 	private CommerceCurrencyLocalService _commerceCurrencyLocalService;
 
 	@Reference
@@ -700,6 +756,9 @@ public class CommerceSiteInitializer {
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private OptionResource.Factory _optionResourceFactory;

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/commerce-channel.default-product-display-page.json
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/commerce-channel.default-product-display-page.json
@@ -1,0 +1,4 @@
+{
+	"friendlyURL": "/starter-kit-detail",
+	"privateLayout": false
+}


### PR DESCRIPTION
Dear Team, I moved the code to CommerceSiteInitializer as you mentioned. 

As the original PR mentioned, the idea of the PR is to automate the product display page in the commerce channel. Please let me know what you think and if it would be better to use other namings. I used resource model resource permission naming as a base (prefixed with commerce channel).

Thanks as always!

