### PR TITLE
LPS-153406 [CP 2.0] [Impedibug] User with partner manager role in the project is currently able to change the role

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/containers/TeamMembersTable/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/containers/TeamMembersTable/index.js
@@ -84,7 +84,8 @@ const TeamMembersTable = ({licenseKeyDownloadURL, project, sessionId}) => {
 				const isSupportSeatRole = currentSelectedUser?.roles?.some(
 					(role) =>
 						role === ROLE_TYPES.admin.key ||
-						role === ROLE_TYPES.requester.key
+						role === ROLE_TYPES.requester.key ||
+						role === ROLE_TYPES.partnerManager.key
 				);
 				const filteredRoles = accountRoles.map((role) => {
 					const isAdministratorOrRequestor =


### PR DESCRIPTION
Fix when the current user is with the partner manager role in the project, he is allowed to change his role if the current user is the only admin or partner manager.