### PR TITLE
LPS-153866 [CP 2.0] Hide the "Subscriptions" header when the only subscription group is Partnership

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/Project/Overview/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/Project/Overview/index.js
@@ -21,7 +21,7 @@ import SubscriptionsFilterByStatus from '../../../components/SubscriptionsFilter
 import SubscriptionsNavbar from '../../../components/SubscriptionsNavbar';
 import {useCustomerPortal} from '../../../context';
 import {actionTypes} from '../../../context/reducer';
-import {SUBSCRIPTIONS_STATUS} from '../../../utils/constants';
+import {PRODUCT_TYPES, SUBSCRIPTIONS_STATUS} from '../../../utils/constants';
 import {getWebContents} from '../../../utils/getWebContents';
 import OverviewSkeleton from './Skeleton';
 
@@ -130,7 +130,9 @@ const Overview = () => {
 		<>
 			<ProjectSupport />
 			<div className="d-flex flex-column mr-4 mt-6">
-				<h3>{i18n.translate('subscriptions')}</h3>
+				{selectedSubscriptionGroup !== PRODUCT_TYPES.partnership && (
+					<h3>{i18n.translate('subscriptions')}</h3>
+				)}
 
 				{!!subscriptionGroupsWithSubscriptions.length && (
 					<>


### PR DESCRIPTION
If the only subscription group is Partnership, the "Subscriptions" header should be hidden. 