### PR TITLE
[TS]LPS-159924 Questions widget "My Subscriptions" incorrectly shows all message board subscriptions

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserSubscriptions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserSubscriptions.es.js
@@ -60,6 +60,12 @@ export default withRouter(({history, location}) => {
 		}
 	);
 
+	if (threads && threads.myUserAccountSubscriptions.items) {
+		threads.myUserAccountSubscriptions.items = threads.myUserAccountSubscriptions.items.filter(
+			(thread) => thread.graphQLNode.showAsQuestion
+		);
+	}
+
 	const {data: topics, refetch: refetchTopics} = useQuery(
 		getSubscriptionsQuery,
 		{

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/utils/client.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/utils/client.es.js
@@ -951,6 +951,7 @@ export const getSubscriptionsQuery = `
 						myRating {
 							ratingValue
 						}
+						showAsQuestion
 						subscribed
 						viewCount
 					}


### PR DESCRIPTION
Notes from @javalosjr96:

> Ticket:
> https://issues.liferay.com/browse/LPS-159924
> 
> Issue:
> When attempting to view the questions that the user is subscribed to, all threads are shown instead of threads marked as questions.  
> 
> Solution:
> Add showAsQuestion as a returned variable in graphQL query and filter out questions in js using showAsQuestion.
> 