### PR TITLE
LPS-160954 [Raylife AP] Center Status doesn't change after user change Vehicle's field on Coverage

### DIFF
--- a/modules/apps/site-initializer/site-initializer-raylife-ap/extra/remote-app/src/routes/applications/forms/steps/Coverage/CoverageInfoForm.tsx
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/extra/remote-app/src/routes/applications/forms/steps/Coverage/CoverageInfoForm.tsx
@@ -96,6 +96,7 @@ const CoverageInfoForm = () => {
 			},
 			type: ACTIONS.SET_COVERAGE_FORM,
 		});
+		dispatch({payload: true, type: ACTIONS.SET_HAS_FORM_CHANGE});
 	};
 
 	const [hasError, setHasError] = useState(hasRequiredError);
@@ -275,6 +276,7 @@ const CoverageInfoForm = () => {
 									collisionValue === 'CHOOSE AN OPTION'
 										? ''
 										: collisionValue;
+
 								setHasError({
 									...hasError,
 									collision:


### PR DESCRIPTION
Sub task [LPS-160954](https://issues.liferay.com/browse/LPS-160954)