### PR TITLE
LPS-161291: Creating a topic with backspace at first leads to an error

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/NewTopicModal.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/NewTopicModal.es.js
@@ -61,14 +61,15 @@ export default function NewTopicModal({
 	};
 
 	const createTopic = () => {
-		if (isValidTopic(topicNameRef.current.value)) {
+		const topicName = topicNameRef.current.value.trim();
+		if (isValidTopic(topicName)) {
 			deleteCache();
 			if (currentSectionId) {
 				createNewSubTopic({
 					variables: {
 						description: topicDescriptionRef.current.value,
 						parentMessageBoardSectionId: currentSectionId,
-						title: topicNameRef.current.value,
+						title: topicName,
 					},
 				}).then(
 					({
@@ -88,7 +89,7 @@ export default function NewTopicModal({
 					variables: {
 						description: topicDescriptionRef.current.value,
 						siteKey: context.siteKey,
-						title: topicNameRef.current.value,
+						title: topicName,
 					},
 				}).then(({data: {createSiteMessageBoardSection: section}}) =>
 					onCreateNavigateTo(


### PR DESCRIPTION
Dear Team,

 Here is the PR for fixing https://issues.liferay.com/browse/LPS-161291.
 After investigating the flow, I recognize that when a Topic was created, these spacing characters should be removed from its name at the beginning and ending. So my solution is to remove them by trim() function. Please help me review and leave your comments,

Thanks,
Thien