### PR TITLE
LPS-166775 fixed close button positon in questions

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,6 +1,10 @@
 @import 'atlas-variables';
 @import 'pages';
 
+.alert-inline.alert .close {
+	top: 20% !important;
+}
+
 .stretched-link-layer {
 	position: relative;
 	z-index: 2;


### PR DESCRIPTION
**Link for issue:** https://issues.liferay.com/browse/LPS-166775

The issue was, the X button from question toast was out of place. It was caused by the `variant="inline"` property.

Following @brenobcos advise i defined the position using CSS and used `!important` to overwrite the previous placement configurations.