### PR TITLE
LPS-171186 Setting useCache to false

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/EditQuestion.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/EditQuestion.es.js
@@ -44,6 +44,7 @@ export default withRouter(
 		const [tagsLoaded, setTagsLoaded] = useState(true);
 
 		const {data = {}} = useQuery(getThreadContentQuery, {
+			useCache: false,
 			variables: {
 				friendlyUrlPath: questionId,
 				siteKey: context.siteKey,


### PR DESCRIPTION
[LPS-171186](https://issues.liferay.com/browse/LPS-171186) Setting useCache to false, this way the edit button will make a new requisition, instead of searching data on cache.