### PR TITLE
COMMERCE-9372 Use DynamicImport-Package instead of optional Import-Package. It prevents startup order issues when the site initializer extender bundle resolves before the commerce ones that provide the optional imports. See https://docs.osgi.org/specification/osgi.core/7.0.0/framework.module.html#i2548181

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/bnd.bnd
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/bnd.bnd
@@ -1,8 +1,6 @@
 Bundle-Name: Liferay Site Initializer Extender
 Bundle-SymbolicName: com.liferay.site.initializer.extender
 Bundle-Version: 1.0.72
-Import-Package:\
-	com.liferay.commerce.*;resolution:=optional,\
-	com.liferay.headless.commerce.*;resolution:=optional,\
-	\
-	*
+DynamicImport-Package:\
+	com.liferay.commerce.*,\
+	com.liferay.headless.commerce.*


### PR DESCRIPTION
Issue: https://issues.liferay.com/browse/COMMERCE-9372