### PR TITLE
LPS-174368 [CP] Mismatching dates on koroneiki/provisioning to CP2.0

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/utils/getDateCustomFormat.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/utils/getDateCustomFormat.js
@@ -11,6 +11,7 @@
 import {Liferay} from '../services/liferay';
 
 export default function getDateCustomFormat(rawDate, format) {
+	rawDate = rawDate.substring(0, rawDate.length - 1);
 	const date = new Date(rawDate);
 
 	return date.toLocaleDateString(


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-174368