### PR TITLE
LPS-174180 [CP 2.0] The elements in the banner on Activation Status tab is overlapping

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/components/ActivationStatus/Layout/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/components/ActivationStatus/Layout/index.js
@@ -53,10 +53,11 @@ const ActivationStatusLayout = ({
 							/>
 
 							<ClayCard.Description
-								className="col-8 h5 ml-2 px-0 text-truncate"
+								className="col-7 h5 ml-2 px-0"
 								displayType="title"
 								tag="h5"
 								title={project.name}
+								truncate={false}
 							>
 								{project.name}
 


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-174180