### PR TITLE
LPS-176985 | Rollback site update with site initializer if process fails

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-web/build.gradle
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-web/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	dependencies {
+		compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 		compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 		compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 		compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-web/src/main/java/com/liferay/site/initializer/extender/web/internal/portlet/action/SynchronizeSiteInitializerMVCActionCommand.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-web/src/main/java/com/liferay/site/initializer/extender/web/internal/portlet/action/SynchronizeSiteInitializerMVCActionCommand.java
@@ -18,14 +18,20 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
-import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.GroupService;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerFactory;
 import com.liferay.site.initializer.SiteInitializerRegistry;
@@ -33,6 +39,8 @@ import com.liferay.site.initializer.extender.web.internal.constants.SiteInitiali
 
 import java.io.File;
 import java.io.InputStream;
+
+import java.util.concurrent.Callable;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -62,42 +70,19 @@ public class SynchronizeSiteInitializerMVCActionCommand
 			return;
 		}
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
+		Callable<Group> groupCallable = new GroupCallable(actionRequest);
 
-		Group group = _groupLocalService.getGroup(
-			themeDisplay.getScopeGroupId());
-
-		UnicodeProperties unicodeProperties = group.getTypeSettingsProperties();
-
-		String siteInitializerKey = unicodeProperties.get("siteInitializerKey");
-
-		if (Validator.isNull(siteInitializerKey)) {
-			return;
+		try {
+			TransactionInvokerUtil.invoke(_transactionConfig, groupCallable);
+			SessionMessages.add(actionRequest, "synchronizerSiteSuccess");
 		}
-
-		UploadPortletRequest uploadPortletRequest =
-			_portal.getUploadPortletRequest(actionRequest);
-
-		try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
-				"siteInitializerFile")) {
-
-			if (inputStream != null) {
-				_initialize(
-					group.getGroupId(), inputStream, siteInitializerKey);
-
-				return;
-			}
+		catch (Exception exception) {
+			SessionErrors.add(
+				actionRequest, "synchronizerSiteFailException", exception);
 		}
-
-		SiteInitializer siteInitializer =
-			_siteInitializerRegistry.getSiteInitializer(siteInitializerKey);
-
-		if (siteInitializer == null) {
-			return;
+		catch (Throwable throwable) {
+			throw new Exception(throwable);
 		}
-
-		siteInitializer.initialize(group.getGroupId());
 	}
 
 	private void _initialize(
@@ -125,8 +110,52 @@ public class SynchronizeSiteInitializerMVCActionCommand
 		}
 	}
 
+	private Group _updateGroup(ActionRequest actionRequest) throws Exception {
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		Group group = _groupService.getGroup(themeDisplay.getSiteGroupId());
+
+		UnicodeProperties unicodeProperties = group.getTypeSettingsProperties();
+
+		String siteInitializerKey = unicodeProperties.get("siteInitializerKey");
+
+		if (Validator.isNull(siteInitializerKey)) {
+			return null;
+		}
+
+		UploadPortletRequest uploadPortletRequest =
+			_portal.getUploadPortletRequest(actionRequest);
+
+		try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
+				"siteInitializerFile")) {
+
+			if (inputStream != null) {
+				_initialize(
+					group.getGroupId(), inputStream, siteInitializerKey);
+
+				return _groupService.getGroup(themeDisplay.getSiteGroupId());
+			}
+		}
+
+		SiteInitializer siteInitializer =
+			_siteInitializerRegistry.getSiteInitializer(siteInitializerKey);
+
+		if (siteInitializer == null) {
+			return null;
+		}
+
+		siteInitializer.initialize(group.getGroupId());
+
+		return _groupService.getGroup(themeDisplay.getSiteGroupId());
+	}
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
 	@Reference
-	private GroupLocalService _groupLocalService;
+	private GroupService _groupService;
 
 	@Reference
 	private Portal _portal;
@@ -136,5 +165,28 @@ public class SynchronizeSiteInitializerMVCActionCommand
 
 	@Reference
 	private SiteInitializerRegistry _siteInitializerRegistry;
+
+	private class GroupCallable implements Callable<Group> {
+
+		@Override
+		public Group call() throws Exception {
+			try {
+				return _updateGroup(_actionRequest);
+			}
+			catch (Exception exception) {
+				PermissionCacheUtil.clearCache(
+					_portal.getUserId(_actionRequest));
+
+				throw exception;
+			}
+		}
+
+		private GroupCallable(ActionRequest actionRequest) {
+			_actionRequest = actionRequest;
+		}
+
+		private final ActionRequest _actionRequest;
+
+	}
 
 }

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-web/src/main/resources/META-INF/resources/view.jsp
@@ -16,6 +16,8 @@
 
 <%@ include file="/init.jsp" %>
 
+<liferay-ui:success key="synchronizerSiteSuccess" message="Update process done successfully!" />
+
 <clay:container-fluid>
 	<clay:sheet
 		cssClass="custom-sheet"


### PR DESCRIPTION
[Ticket LPS-176985](https://issues.liferay.com/browse/LPS-176985)

**As a liferay user, i want the update site feature to undo the update if the process fails, as to not have the update process break the site or the DXP instance when it fails.**

**Context:** When accessing side-menu and selecting the "site initializer" option, as we put the .jar and select synchronize, the process that runs breaks the whole site and DXP if it fails. We want it to rollback into a usable state on any failure.

**Acceptance Criteria:**

- When clicking Synchronize, if the update process that runs fails, it should be rollbacked into a usable site.
- Add a result box to give feedback to the user
- With the Result: Success or Failure
- A small text container to either show "Update process done successfully!" or the error message that would otherwise be seen in DXP log