### PR TITLE
LPS-182751 - All buttons disappear when editing a case result without status

### DIFF
--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray/extra/remote-app/src/pages/Project/Routines/Builds/Inner/CaseResult/CaseResultEditTest.tsx
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray/extra/remote-app/src/pages/Project/Routines/Builds/Inner/CaseResult/CaseResultEditTest.tsx
@@ -69,11 +69,12 @@ const CaseResultEditTest = () => {
 		defaultValues: caseResult?.dueStatus
 			? ({
 					comment: mbMessage?.articleBody,
-					dueStatus:
-						caseResult?.dueStatus.key ===
-						CaseResultStatuses.IN_PROGRESS
-							? CaseResultStatuses.PASSED
-							: caseResult?.dueStatus.key,
+					dueStatus: [
+						CaseResultStatuses.IN_PROGRESS,
+						CaseResultStatuses.UNTESTED,
+					].includes(caseResult?.dueStatus.key as CaseResultStatuses)
+						? CaseResultStatuses.PASSED
+						: caseResult?.dueStatus.key,
 					issues,
 			  } as any)
 			: {},

--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray/extra/remote-app/src/pages/Project/Routines/Builds/Inner/CaseResult/CaseResultEditTest.tsx
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray/extra/remote-app/src/pages/Project/Routines/Builds/Inner/CaseResult/CaseResultEditTest.tsx
@@ -140,6 +140,7 @@ const CaseResultEditTest = () => {
 			</ClayAlert>
 
 			<Form.Select
+				{...inputProps}
 				className="container-fluid-max-md"
 				defaultOption={false}
 				label={i18n.translate('status')}


### PR DESCRIPTION
Related Issue: [LPS-182751](https://issues.liferay.com/browse/LPS-182751)