### PR TITLE
LPS-181600 [PRM] The invoices about unselected budgets are being displayed in Claim Detail Page

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFClaimForm/components/MDFClaimPage/MDFClaimPage.tsx
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFClaimForm/components/MDFClaimPage/MDFClaimPage.tsx
@@ -107,7 +107,7 @@ const MDFClaimPage = ({
 			);
 		}
 
-		if (claimsFiltered && claimsFiltered >= 2) {
+		if (claimsFiltered && claimsFiltered >= 2 && !values.id) {
 			return (
 				<PRMForm name="New" title="Reimbursement Claim">
 					<div className="d-flex justify-content-center mt-4">

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/ActivityClaimPanel.tsx
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/ActivityClaimPanel.tsx
@@ -77,8 +77,9 @@ const ActivityClaimPanel = ({
 		)
 	);
 	const displayActivityClaimCheckbox =
-		activity.activityStatus?.key !== Status.EXPIRED.key &&
-		!activity.claimed;
+		(activity.activityStatus?.key !== Status.EXPIRED.key &&
+			!activity.claimed) ||
+		activity.id;
 
 	return (
 		<>

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/ActivityClaimPanel.tsx
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/ActivityClaimPanel.tsx
@@ -79,7 +79,7 @@ const ActivityClaimPanel = ({
 	const displayActivityClaimCheckbox =
 		(activity.activityStatus?.key !== Status.EXPIRED.key &&
 			!activity.claimed) ||
-		activity.id;
+		(activity.id && activity.selected);
 
 	return (
 		<>

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFClaimForm/utils/getInitialFormValues.ts
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFClaimForm/utils/getInitialFormValues.ts
@@ -59,7 +59,8 @@ const getInitialFormValues = (
 					?.map((mdfClaimActivity) => {
 						return (
 							mdfClaimActivity?.r_mdfClmToMDFClmActs_c_mdfClaim
-								?.mdfClaimStatus.key !== 'draft'
+								?.mdfClaimStatus.key !== 'draft' &&
+							mdfClaimActivity.selected
 						);
 					})
 					.includes(true),
@@ -83,7 +84,8 @@ const getInitialFormValues = (
 				?.map((mdfClaimActivity) => {
 					return (
 						mdfClaimActivity?.r_mdfClmToMDFClmActs_c_mdfClaim
-							?.mdfClaimStatus.key !== 'draft'
+							?.mdfClaimStatus.key !== 'draft' &&
+						mdfClaimActivity.selected
 					);
 				})
 				.includes(true),

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFClaimForm/utils/submitForm.ts
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFClaimForm/utils/submitForm.ts
@@ -41,48 +41,50 @@ export default async function submitForm(
 ) {
 	formikHelpers.setSubmitting(true);
 
+	const submitValues = {...values};
+
 	const updatedStatus = updateStatus(
-		values.mdfClaimStatus,
+		submitValues.mdfClaimStatus,
 		currentClaimStatus,
 		false,
-		values.id
+		submitValues.id
 	);
 
-	values.mdfClaimStatus = updatedStatus;
+	submitValues.mdfClaimStatus = updatedStatus;
 
-	values.partial = values.activities?.some((activity) =>
+	submitValues.partial = submitValues.activities?.some((activity) =>
 		Boolean(activity.budgets?.some((budget) => !budget.selected))
 	);
 
 	let dtoMDFClaim: mdfClaimDTO | undefined = undefined;
 
-	if (values.mdfClaimStatus.key !== Status.DRAFT.key) {
-		dtoMDFClaim = await createMDFClaimProxyAPI(values, mdfRequest);
+	if (submitValues.mdfClaimStatus.key !== Status.DRAFT.key) {
+		dtoMDFClaim = await createMDFClaimProxyAPI(submitValues, mdfRequest);
 	}
-	else if (values.id) {
+	else if (submitValues.id) {
 		dtoMDFClaim = await updateMDFClaim(
 			ResourceName.MDF_CLAIM_DXP,
-			values,
+			submitValues,
 			mdfRequest,
-			values.id
+			submitValues.id
 		);
 	}
 	else {
 		dtoMDFClaim = await createMDFClaim(
 			ResourceName.MDF_CLAIM_DXP,
-			values,
+			submitValues,
 			mdfRequest
 		);
 	}
 
 	if (
-		values.reimbursementInvoice &&
-		!values.reimbursementInvoice.id &&
+		submitValues.reimbursementInvoice &&
+		!submitValues.reimbursementInvoice.id &&
 		dtoMDFClaim?.id
 	) {
 		const reimbursementInvoiceRenamed = renameFileKeepingExtention(
-			values.reimbursementInvoice,
-			`${values.reimbursementInvoice.name}#${dtoMDFClaim.id}`
+			submitValues.reimbursementInvoice,
+			`${submitValues.reimbursementInvoice.name}#${dtoMDFClaim.id}`
 		);
 
 		if (reimbursementInvoiceRenamed) {
@@ -94,7 +96,7 @@ export default async function submitForm(
 			if (dtoReimbursementInvoice.id) {
 				await updateMDFClaim(
 					ResourceName.MDF_CLAIM_DXP,
-					values,
+					submitValues,
 					mdfRequest,
 					dtoMDFClaim.id,
 					dtoReimbursementInvoice.id as LiferayFile & number,
@@ -104,9 +106,9 @@ export default async function submitForm(
 		}
 	}
 
-	if (values.activities?.length && dtoMDFClaim?.id) {
+	if (submitValues.activities?.length && dtoMDFClaim?.id) {
 		await Promise.all(
-			values.activities.map(async (activity) => {
+			submitValues.activities.map(async (activity) => {
 				const dtoMDFClaimActivity = activity.id
 					? await updateMDFClaimActivity(
 							activity,

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFRequestList/MDFRequestList.tsx
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFRequestList/MDFRequestList.tsx
@@ -117,7 +117,7 @@ const MDFRequestList = () => {
 			);
 		}
 	};
-	const buildFilterFields = () => {
+	const getFilters = () => {
 		const filterFields = [
 			{
 				component: (
@@ -238,7 +238,7 @@ const MDFRequestList = () => {
 					<DropDownWithDrillDown
 						className=""
 						initialActiveMenu="x0a0"
-						menus={getDropDownFilterMenus(buildFilterFields())}
+						menus={getDropDownFilterMenus(getFilters())}
 						trigger={
 							<ClayButton borderless className="btn-secondary">
 								<span className="inline-item inline-item-before">

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFRequestList/MDFRequestList.tsx
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/extra/remote-app/src/routes/MDFRequestList/MDFRequestList.tsx
@@ -117,6 +117,73 @@ const MDFRequestList = () => {
 			);
 		}
 	};
+	const buildFilterFields = () => {
+		const filterFields = [
+			{
+				component: (
+					<DateFilter
+						dateFilters={(dates: {
+							endDate: string;
+							startDate: string;
+						}) => {
+							onFilter({
+								activityPeriod: {
+									dates,
+								},
+							});
+						}}
+						filterDescription="Activity Date "
+					/>
+				),
+				name: 'Activity Period',
+			},
+			{
+				component: (
+					<CheckboxFilter
+						availableItems={fieldEntries[
+							LiferayPicklistName.MDF_REQUEST_STATUS
+						]?.map<string>((status) => status.label as string)}
+						clearCheckboxes={!filters.status.value?.length}
+						updateFilters={(checkedItems) =>
+							setFilters((previousFilters) => ({
+								...previousFilters,
+								status: {
+									...previousFilters.status,
+									value: checkedItems,
+								},
+							}))
+						}
+					/>
+				),
+				name: 'Status',
+			},
+		];
+
+		if (actions?.includes(PermissionActionType.SEE_RESTRICTED_FIELDS)) {
+			filterFields.push({
+				component: (
+					<CheckboxFilter
+						availableItems={companiesEntries?.map<string>(
+							(company) => company.label as string
+						)}
+						clearCheckboxes={!filters.partner.value?.length}
+						updateFilters={(checkedItems) =>
+							setFilters((previousFilters) => ({
+								...previousFilters,
+								partner: {
+									...previousFilters.status,
+									value: checkedItems,
+								},
+							}))
+						}
+					/>
+				),
+				name: 'Partner',
+			});
+		}
+
+		return filterFields;
+	};
 
 	return (
 		<div className="border-0 my-4">
@@ -171,73 +238,7 @@ const MDFRequestList = () => {
 					<DropDownWithDrillDown
 						className=""
 						initialActiveMenu="x0a0"
-						menus={getDropDownFilterMenus([
-							{
-								component: (
-									<DateFilter
-										dateFilters={(dates: {
-											endDate: string;
-											startDate: string;
-										}) => {
-											onFilter({
-												activityPeriod: {
-													dates,
-												},
-											});
-										}}
-										filterDescription="Activity Date "
-									/>
-								),
-								name: 'Activity Period',
-							},
-							{
-								component: (
-									<CheckboxFilter
-										availableItems={fieldEntries[
-											LiferayPicklistName
-												.MDF_REQUEST_STATUS
-										]?.map<string>(
-											(status) => status.label as string
-										)}
-										clearCheckboxes={
-											!filters.status.value?.length
-										}
-										updateFilters={(checkedItems) =>
-											setFilters((previousFilters) => ({
-												...previousFilters,
-												status: {
-													...previousFilters.status,
-													value: checkedItems,
-												},
-											}))
-										}
-									/>
-								),
-								name: 'Status',
-							},
-							{
-								component: (
-									<CheckboxFilter
-										availableItems={companiesEntries?.map<
-											string
-										>((company) => company.label as string)}
-										clearCheckboxes={
-											!filters.partner.value?.length
-										}
-										updateFilters={(checkedItems) =>
-											setFilters((previousFilters) => ({
-												...previousFilters,
-												partner: {
-													...previousFilters.status,
-													value: checkedItems,
-												},
-											}))
-										}
-									/>
-								),
-								name: 'Partner',
-							},
-						])}
+						menus={getDropDownFilterMenus(buildFilterFields())}
 						trigger={
 							<ClayButton borderless className="btn-secondary">
 								<span className="inline-item inline-item-before">

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/mdf-claim-manager-status/index.html
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/mdf-claim-manager-status/index.html
@@ -18,7 +18,7 @@
 	[#if mdfClaimStatusKey != 'approved']
 		[#if hasMarketingReviewAction || hasFinanceReviewAction || hasRequestMoreInfoAction || hasExpireAction || hasRejectAction || hasApproveAction || hasDirectorReviewAction]
 			<script>
-				const updateStatus = async (status) => {
+				const updateClaimStatus = async (status) => {
 					const responde = await fetch(
 						`/o/c/mdfclaims/${mdfClaimId}`,
 						{
@@ -27,7 +27,7 @@
 								'content-type': 'application/json',
 								'x-csrf-token': Liferay.authToken,
 							},
-							method: 'PATCH',
+							method: 'PUT',
 						}
 					);
 
@@ -47,7 +47,7 @@
 					message: 'Are you sure?',
 					onConfirm: (isConfirmed) => {
 						if (isConfirmed) {
-							updateStatus(status);
+							updateClaimStatus(status);
 						}
 					},
 				});

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/activities-list-panel/index.html
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/activities-list-panel/index.html
@@ -91,7 +91,7 @@
 [/#macro]
 
 [#macro claim_status activity_claims]
-	[#assign claim_status_content = activity_claims?filter(activity_claim -> activity_claim.r_mdfClmToMDFClmActs_c_mdfClaim.mdfClaimStatus.key != "draft")?has_content?string("claimed", "unclaimed") /]
+	[#assign claim_status_content = activity_claims?filter(activity_claim -> activity_claim.r_mdfClmToMDFClmActs_c_mdfClaim.mdfClaimStatus.key != "draft" && activity_claim.selected)?has_content?string("claimed", "unclaimed") /]
 
 	<div class="align-items-center d-sm-flex mb-1 text-neutral-7 text-weight-semi-bold">
 		Claim Status: <span class="${claim_status_style[claim_status_content]}">${claim_status_content?capitalize}</span>

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/claims-list-on-mdf-request-detail/index.html
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/claims-list-on-mdf-request-detail/index.html
@@ -1,9 +1,7 @@
 [#assign mdf_request_id = (request.getAttribute("INFO_ITEM").objectEntryId)! /]
+[#assign siteURL = (themeDisplay.getURLCurrent()?keep_before("/l"))! /]
 
-[#assign permissionAction = restClient.get("/c/permissionactions?filter=object%20eq%20%27MDF%20Claim%27&pageSize=-1") /]
-[#assign hasDeleteAction = permissionAction.items?filter(permissionAction -> permissionAction.action == "DELETE")?has_content /]
-
-[#assign claim_status_style = {"draft": "label label-tonal-dark ml-2", "pendingMarketingReview": "label label-tonal-warning ml-2", "approved": "label label-tonal-success ml-2", "moreInfoRequested": "label label-tonal-warning ml-2", "rejected": "label label-tonal-danger ml-2", "expired": "label label-tonal-danger ml-2", "claimPaid": "label label-tonal-info ml-2", "inFinanceReview": "label label-tonal-light ml-2", "canceled": "label label-tonal-danger ml-2"}]
+[#assign claim_status_style = {"draft": "label label-tonal-dark ml-md-2", "pendingMarketingReview": "label label-tonal-warning ml-md-2", "approved": "label label-tonal-success ml-md-2", "moreInfoRequested": "label label-tonal-warning ml-md-2", "rejected": "label label-tonal-danger ml-md-2", "expired": "label label-tonal-danger ml-md-2", "claimPaid": "label label-tonal-info ml-md-2", "inFinanceReview": "label label-tonal-light ml-md-2", "canceled": "label label-tonal-danger ml-md-2"}]
 
 [#function check_claim status_key]
 	[#return status_key != "draft" && status_key != "expired" && status_key != "rejected" /]
@@ -14,6 +12,14 @@
 [/#function]
 
 [#macro panel claim site_url]
+	[#assign permissionAction = restClient.get("/c/permissionactions?filter=object%20eq%20%27MDF%20Claim%27&pageSize=-1") /]
+	[#assign hasDeleteAction = permissionAction.items?filter(permissionAction -> permissionAction.action == "DELETE")?has_content /]
+	[#assign hasUpdateAction = permissionAction.items?filter(permissionAction -> permissionAction.action == "UPDATE")?has_content /]
+
+	[#assign currentMDFClaimHasValidStatusToEdit = claim.mdfClaimStatus.key == 'draft' || claim.mdfClaimStatus.key == 'moreInfoRequested' /]
+	[#assign accountEntryId = claim.r_accToMDFClms_accountEntryId /]
+	[#assign myUserAccount = restClient.get("/headless-admin-user/v1.0/my-user-account") /]
+	[#assign isUserAssociated = myUserAccount.accountBriefs?filter(accountBrief -> accountBrief.id == accountEntryId)?has_content /]
 	<div>
 		<div class="text-neutral-7 text-paragraph-xs">
 			Type: ${claim.partial?string('Partial','Full')}
@@ -24,7 +30,7 @@
 		</div>
 
 		<div class="align-items-baseline d-flex justify-content-between">
-			<div class="align-items-baseline d-flex">
+			<div class="align-items-baseline d-md-flex">
 				<p class="font-weight-bold text-neutral-9 text-paragraph-sm">
 					Claimed ${get_currency(claim.totalClaimAmount, (claim.currency.key)!"USD")}
 				</p>
@@ -34,14 +40,20 @@
 				</div>
 			</div>
 
-			<div>
+			<div class="d-flex">
+				[#if hasUpdateAction && isUserAssociated && currentMDFClaimHasValidStatusToEdit]
+					<a class="btn" href="${siteURL}/marketing/mdf-claims/edit/#/mdf-request/${mdf_request_id}/mdf-claim/${claim.id}">
+						[@clay["icon"] symbol="pencil"/]
+					</a>
+				[/#if]
+
 				[#if hasDeleteAction && claim.mdfClaimStatus.key == "draft"]
 					<a class="btn" onClick="callDeleteMDFClaimList(${claim.id})">
 						[@clay["icon"] symbol="trash"/]
 					</a>
 				[/#if]
 
-				<a class="btn btn-secondary btn-sm" href="${site_url}/l/${claim.id}">
+				<a class="align-items-center btn btn-secondary btn-sm d-flex my-2" href="${site_url}/l/${claim.id}">
 					View
 				</a>
 			</div>

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/mdf-request-details-summary/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/mdf-request-details-summary/index.js
@@ -44,8 +44,6 @@ const updateMDFDetailsSummary = async () => {
 			Liferay.Util.escape(data.totalMDFRequestAmount),
 			data.currency ? Liferay.Util.escape(data.currency.key) : 'USD'
 		);
-		const totalCostCurrency = data.currency ? data.currency.key : ' ';
-		const requestedCostCurrency = data.currency ? data.currency.key : ' ';
 
 		fragmentElement.querySelector(
 			'#mdf-request-date-field'
@@ -56,12 +54,6 @@ const updateMDFDetailsSummary = async () => {
 		fragmentElement.querySelector(
 			'#mdf-request-requested-cost'
 		).innerHTML = requestedCost;
-		fragmentElement.querySelector(
-			'#mdf-request-total-cost-currency'
-		).innerHTML = totalCostCurrency;
-		fragmentElement.querySelector(
-			'#mdf-request-requested-cost-currency'
-		).innerHTML = requestedCostCurrency;
 
 		return;
 	}

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/mdf-request-manager-status/index.html
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/mdf-request-manager-status/index.html
@@ -30,7 +30,7 @@
 				[/#list]
 			};
 
-			const updateStatus = async (status) => {
+			const updateRequestStatus = async (status) => {
 				const responde = await fetch(
 					`/o/c/mdfrequests/${mdfRequestId}`,
 					{
@@ -39,7 +39,7 @@
 							'content-type': 'application/json',
 							'x-csrf-token': Liferay.authToken,
 						},
-						method: 'PATCH',
+						method: 'PUT',
 					}
 				);
 
@@ -63,7 +63,7 @@
 				message: 'Are you sure?',
 				onConfirm: (isConfirmed) => {
 					if (isConfirmed) {
-						updateStatus(status);
+						updateRequestStatus(status);
 					}
 				},
 			});


### PR DESCRIPTION
[LPS-181600](https://issues.liferay.com/browse/LPS-181600)
The invoices about unselected budgets are being displayed in Claim Detail Page

[LPS-181717](https://issues.liferay.com/browse/LPS-181717)
it is not possible to edit the claim when two claims have already been made in an MDF Request

[LPS-182115](https://issues.liferay.com/browse/LPS-182115)
It's possible to submit a Claim without fill the budget invoice when the Claim is edited

[LPS-183146](https://issues.liferay.com/browse/LPS-183146)
It's not possible to submit a second claim

[LPS-182117](https://issues.liferay.com/browse/LPS-182117)
MDF Claim save as Draft is buggy and canceling the Draft crashes MDF request's claim submission

[LPS-181518](https://issues.liferay.com/browse/LPS-181518)
Update MDF Listing filter for partner view