### PR TITLE
LPD-75044 OSGi bundle remains unresolved after license activation

### DIFF
--- a/modules/core/portal-app-license-resolver-hook/src/main/java/com/liferay/portal/app/license/resolver/hook/AppResolverHook.java
+++ b/modules/core/portal-app-license-resolver-hook/src/main/java/com/liferay/portal/app/license/resolver/hook/AppResolverHook.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Filter;
@@ -39,12 +40,14 @@ public class AppResolverHook implements ResolverHook {
 
 	public AppResolverHook(
 		ServiceTracker<AppLicenseVerifier, AppLicenseVerifier> serviceTracker,
-		Set<String> filteredBundleSymbolicNames,
-		Set<String> filteredProductIds) {
+		Set<String> filteredBundleSymbolicNames, Set<String> filteredProductIds,
+		AtomicBoolean readyToResolve, Set<Bundle> resolveBundles) {
 
 		_serviceTracker = serviceTracker;
 		_filteredBundleSymbolicNames = filteredBundleSymbolicNames;
 		_filteredProductIds = filteredProductIds;
+		_readyToResolve = readyToResolve;
+		_resolveBundles = resolveBundles;
 	}
 
 	@Override
@@ -88,6 +91,13 @@ public class AppResolverHook implements ResolverHook {
 			String productId = (String)properties.get("product-id");
 
 			if (productId == null) {
+				continue;
+			}
+
+			if (!_readyToResolve.get()) {
+				_resolveBundles.add(bundle);
+				iterator.remove();
+
 				continue;
 			}
 
@@ -197,6 +207,8 @@ public class AppResolverHook implements ResolverHook {
 
 	private final Set<String> _filteredBundleSymbolicNames;
 	private final Set<String> _filteredProductIds;
+	private final AtomicBoolean _readyToResolve;
+	private final Set<Bundle> _resolveBundles;
 	private final ServiceTracker<AppLicenseVerifier, AppLicenseVerifier>
 		_serviceTracker;
 

--- a/modules/core/portal-app-license-resolver-hook/src/main/java/com/liferay/portal/app/license/resolver/hook/AppResolverHookFactory.java
+++ b/modules/core/portal-app-license-resolver-hook/src/main/java/com/liferay/portal/app/license/resolver/hook/AppResolverHookFactory.java
@@ -6,16 +6,23 @@
 package com.liferay.portal.app.license.resolver.hook;
 
 import com.liferay.portal.app.license.AppLicenseVerifier;
+import com.liferay.portal.kernel.util.ModuleFrameworkPropsValues;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.FrameworkListener;
 import org.osgi.framework.hooks.resolver.ResolverHook;
 import org.osgi.framework.hooks.resolver.ResolverHookFactory;
+import org.osgi.framework.startlevel.FrameworkStartLevel;
 import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.FrameworkWiring;
 import org.osgi.util.tracker.ServiceTracker;
 
 /**
@@ -24,6 +31,44 @@ import org.osgi.util.tracker.ServiceTracker;
 public class AppResolverHookFactory implements ResolverHookFactory {
 
 	public AppResolverHookFactory(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+
+		_frameworkListener = new FrameworkListener() {
+
+			@Override
+			public void frameworkEvent(FrameworkEvent frameworkEvent) {
+				if ((frameworkEvent.getType() ==
+						FrameworkEvent.STARTLEVEL_CHANGED) &&
+					!_readyToResolve.get()) {
+
+					Bundle bundle = frameworkEvent.getBundle();
+
+					FrameworkStartLevel frameworkStartLevel = bundle.adapt(
+						FrameworkStartLevel.class);
+
+					if (frameworkStartLevel.getStartLevel() >=
+							ModuleFrameworkPropsValues.
+								MODULE_FRAMEWORK_DYNAMIC_INSTALL_START_LEVEL) {
+
+						_readyToResolve.set(true);
+
+						FrameworkWiring frameworkWiring = bundle.adapt(
+							FrameworkWiring.class);
+
+						frameworkWiring.resolveBundles(_resolveBundles);
+
+						_resolveBundles.clear();
+
+						_bundleContext.removeFrameworkListener(
+							_frameworkListener);
+					}
+				}
+			}
+
+		};
+
+		bundleContext.addFrameworkListener(_frameworkListener);
+
 		_serviceTracker = new ServiceTracker<>(
 			bundleContext, AppLicenseVerifier.class, null);
 
@@ -33,16 +78,24 @@ public class AppResolverHookFactory implements ResolverHookFactory {
 	@Override
 	public ResolverHook begin(Collection<BundleRevision> triggers) {
 		return new AppResolverHook(
-			_serviceTracker, _filteredBundleSymbolicNames, _filteredProductIds);
+			_serviceTracker, _filteredBundleSymbolicNames, _filteredProductIds,
+			_readyToResolve, _resolveBundles);
 	}
 
 	public void close() {
 		_serviceTracker.close();
+
+		_bundleContext.removeFrameworkListener(_frameworkListener);
 	}
 
+	private final BundleContext _bundleContext;
 	private final Set<String> _filteredBundleSymbolicNames =
 		Collections.newSetFromMap(new ConcurrentHashMap<>());
 	private final Set<String> _filteredProductIds = Collections.newSetFromMap(
+		new ConcurrentHashMap<>());
+	private final FrameworkListener _frameworkListener;
+	private final AtomicBoolean _readyToResolve = new AtomicBoolean();
+	private final Set<Bundle> _resolveBundles = Collections.newSetFromMap(
 		new ConcurrentHashMap<>());
 	private final ServiceTracker<AppLicenseVerifier, AppLicenseVerifier>
 		_serviceTracker;


### PR DESCRIPTION
Summary
This PR addresses the issue where OSGi bundles remain in an unresolved state even after a valid license is activated in the portal. The implementation is based on the Proof of Concept (PoC) developed by Eric Yan as part of ticket LPD-75044.

Context
It was identified that, in certain scenarios, Marketplace licensing was not being correctly verified after static modules had started. This led to a failure in resolving dependencies for modules that require an active license check to proceed.

Jira ticket [LPD-75044](https://liferay.atlassian.net/browse/LPD-75044) was opened to investigate this behavior. During the process, Eric Yan created a PoC that introduces a specific check for Marketplace licensing immediately after the static modules are initialized.

Changes
Added logic to trigger the Marketplace licensing check after static modules have started.

Integrated the code created by Eric Yan in his PoC, which I have successfully validated and tested to ensure it resolves the reported issue.

Related JIRA Ticket
[LPD-75044 - OSGi bundle remains unresolved after license activation](https://liferay.atlassian.net/browse/LPD-75044)

Additional Notes
This PR directly applies Eric Yan's proposed solution, which proved effective during local validation.