### PR TITLE
LPD-89414 LPD-89413 Reference Projects in home page descriptions

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/01_home/page-definition.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/01_home/page-definition.json
@@ -143,10 +143,10 @@
 																		},
 																		"text": {
 																			"value_i18n": {
-																				"en_US": "Marketplace, Support, Subscriptions and Account unified into one experience. Browse the catalogue freely or manage your Account.",
-																				"es_ES": "Marketplace, Soporte, Suscripciones y Cuenta unificados en una sola experiencia. Explora el catálogo libremente o gestiona tu Cuenta.",
-																				"ja_JP": "Marketplace、サポート、サブスクリプション、アカウントをひとつの体験に統合。カタログを自由に閲覧、またはアカウントを管理できます。",
-																				"pt_BR": "Marketplace, Suporte, Assinaturas e Conta unificados em uma única experiência. Explore o catálogo livremente ou gerencie sua Conta."
+																				"en_US": "Marketplace, Support, Projects and Account unified into one experience. Browse the catalogue freely or manage your Account.",
+																				"es_ES": "Marketplace, Soporte, Proyectos y Cuenta unificados en una sola experiencia. Explora el catálogo libremente o gestiona tu Cuenta.",
+																				"ja_JP": "Marketplace、サポート、プロジェクト、アカウントをひとつの体験に統合。カタログを自由に閲覧、またはアカウントを管理できます。",
+																				"pt_BR": "Marketplace, Suporte, Projetos e Conta unificados em uma única experiência. Explore o catálogo livremente ou gerencie sua Conta."
 																			}
 																		}
 																	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/01_home/page-definition.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/01_home/page-definition.json
@@ -498,10 +498,10 @@
 																},
 																"text": {
 																	"value_i18n": {
-																		"en_US": "Manage your Liferay account, subscriptions, permissions, fast and efficient.",
-																		"es_ES": "Gestiona tu cuenta, suscripciones y permisos de Liferay, rápido y eficiente.",
-																		"ja_JP": "Liferayアカウント、サブスクリプション、権限を迅速かつ効率的に管理します。",
-																		"pt_BR": "Gerencie sua conta, assinaturas e permissões Liferay de forma rápida e eficiente."
+																		"en_US": "Manage your Liferay account, projects, permissions, fast and efficient.",
+																		"es_ES": "Gestiona tu cuenta, proyectos y permisos de Liferay, rápido y eficiente.",
+																		"ja_JP": "Liferayアカウント、プロジェクト、権限を迅速かつ効率的に管理します。",
+																		"pt_BR": "Gerencie sua conta, projetos e permissões Liferay de forma rápida e eficiente."
 																	}
 																}
 															}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89414

## What Is Being Fixed

The home page hero banner and account card descriptions listed "Subscriptions" as one of the unified experiences, which no longer matches the product offering.

## How It Is Being Fixed

Updated the hero banner description and the account card description in the Liferay One home page definition to reference "Projects" instead of "Subscriptions", across all four locales (en_US, es_ES, ja_JP, pt_BR).

## Why Are There No Tests?

This change only updates localized display text in a site initializer page definition (JSON); there is no code path to test.