### PR TITLE
LPD-93361 Support Liferay Data Platform private beta provisioning

### DIFF
--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/AnalyticsRestController.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/AnalyticsRestController.java
@@ -40,6 +40,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -75,7 +76,9 @@ public class AnalyticsRestController extends BaseRestController {
 			}
 		}
 		catch (Exception exception) {
-			_log.error(exception);
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
 
 			return ResponseEntity.status(
 				HttpStatus.BAD_REQUEST
@@ -184,15 +187,19 @@ public class AnalyticsRestController extends BaseRestController {
 	@GetMapping("project/corpProjectUuid/{corpProjectUuid}")
 	public ResponseEntity<?> getProjectCorpProjectUuid(
 			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable String corpProjectUuid)
+			@PathVariable String corpProjectUuid,
+			@RequestParam String environmentName)
 		throws Exception {
 
 		_accountMemberPermission.check(corpProjectUuid, jwt);
 
-		String analyticsProject = _analyticsService.getCorpProjectUuid(
-			corpProjectUuid);
+		JSONObject analyticsProjectJSONObject =
+			_analyticsService.getCorpProjectUuidJSONObject(
+				_analyticsService.getAnalyticsContextJSONObject(
+					environmentName),
+				corpProjectUuid);
 
-		if (analyticsProject == null) {
+		if (analyticsProjectJSONObject == null) {
 			return ResponseEntity.status(
 				HttpStatus.NOT_FOUND
 			).body(
@@ -203,7 +210,7 @@ public class AnalyticsRestController extends BaseRestController {
 		return ResponseEntity.status(
 			HttpStatus.OK
 		).body(
-			analyticsProject
+			analyticsProjectJSONObject
 		);
 	}
 

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/ObjectActionProductPurchaseRestController.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/ObjectActionProductPurchaseRestController.java
@@ -16,10 +16,12 @@ import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderResource;
 import com.liferay.marketplace.constants.MarketplaceConstants;
 import com.liferay.marketplace.model.SalesforceOpportunity;
+import com.liferay.marketplace.service.AnalyticsService;
 import com.liferay.marketplace.service.KoroneikiService;
 import com.liferay.marketplace.service.MarketplaceService;
 import com.liferay.marketplace.service.SalesforceService;
 import com.liferay.marketplace.util.MarketplaceUtil;
+import com.liferay.osb.koroneiki.phloem.rest.client.dto.v1_0.ProductPurchase;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -437,17 +439,21 @@ public class ObjectActionProductPurchaseRestController
 
 		String solutionType = productSpecificationsMap.get("solution-type");
 
+		if (Objects.equals(solutionType, "ai-hub")) {
+			_setUpCustomAddOn(
+				productSpecificationsMap.get("license-type"), order);
+
+			return;
+		}
+
 		if (Objects.equals(solutionType, "analytics")) {
 			_setUpAnalyticsAddOn(jwt, order);
 
 			return;
 		}
 
-		if (Objects.equals(solutionType, "ai-hub") ||
-			Objects.equals(solutionType, "liferay-data-platform")) {
-
-			_setUpCustomAddOn(
-				productSpecificationsMap.get("license-type"), order);
+		if (Objects.equals(solutionType, "liferay-data-platform")) {
+			_setUpLDPAddOn(jwt, order);
 		}
 	}
 
@@ -538,8 +544,38 @@ public class ObjectActionProductPurchaseRestController
 			});
 	}
 
+	private void _setUpLDPAddOn(Jwt jwt, Order order) throws Exception {
+		ProductPurchase[] productPurchases =
+			_koroneikiService.postAccountProductPurchases(
+				jwt, "3 Months Limited Beta", order);
+
+		ProductPurchase productPurchase = productPurchases[0];
+
+		if (productPurchase == null) {
+			return;
+		}
+
+		JSONObject orderMetadataJSONObject = MarketplaceUtil.getOrderMetadata(
+			order);
+
+		_marketplaceService.updateOrder(
+			HashMapBuilder.put(
+				"order-metadata",
+				orderMetadataJSONObject.put(
+					"analyticsProject",
+					_analyticsService.provisionAnalyticsProject(
+						orderMetadataJSONObject.getJSONObject("analyticsForm"),
+						"internal", order.getAccountExternalReferenceCode())
+				).toString()
+			).build(),
+			order.getId(), MarketplaceConstants.ORDER_STATUS_COMPLETED);
+	}
+
 	private static final Log _log = LogFactory.getLog(
 		ObjectActionProductPurchaseRestController.class);
+
+	@Autowired
+	private AnalyticsService _analyticsService;
 
 	@Autowired
 	private KoroneikiService _koroneikiService;

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/ProvisioningRestController.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/ProvisioningRestController.java
@@ -12,6 +12,7 @@ import com.liferay.marketplace.service.AnalyticsService;
 import com.liferay.marketplace.service.KoroneikiService;
 import com.liferay.marketplace.service.MarketplaceService;
 import com.liferay.marketplace.service.ProvisioningService;
+import com.liferay.marketplace.util.MarketplaceUtil;
 import com.liferay.osb.koroneiki.phloem.rest.client.dto.v1_0.ProductPurchase;
 import com.liferay.osb.provisioning.marketplace.rest.client.dto.v1_0.AppLicenseKey;
 import com.liferay.osb.provisioning.marketplace.rest.client.http.HttpInvoker;
@@ -185,10 +186,14 @@ public class ProvisioningRestController extends BaseRestController {
 
 		AppLicenseKey appLicenseKey = AppLicenseKey.toDTO(json);
 
-		_postAppLicenseKey(
-			appLicenseKey, jwt,
-			_marketplaceService.getOrder(
-				GetterUtil.getLong(appLicenseKey.getOrderId())));
+		Order order = _marketplaceService.getOrder(
+			GetterUtil.getLong(appLicenseKey.getOrderId()));
+
+		_postAppLicenseKey(appLicenseKey, jwt, order);
+
+		_marketplaceService.completeOrder(
+			order.getId(),
+			MarketplaceConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED);
 	}
 
 	@PostMapping("dsr-beta-license-key")
@@ -208,7 +213,24 @@ public class ProvisioningRestController extends BaseRestController {
 
 		_postAppLicenseKey(appLicenseKey, jwt, order);
 
-		_provisionAnalyticsWorkspace(new JSONObject(json), order);
+		JSONObject jsonObject = new JSONObject(json);
+
+		JSONObject analyticsProjectJSONObject =
+			_analyticsService.provisionAnalyticsProject(
+				jsonObject.getJSONObject("analyticsForm"), null,
+				order.getAccountExternalReferenceCode());
+
+		_marketplaceService.completeOrder(
+			HashMapBuilder.put(
+				"order-metadata",
+				MarketplaceUtil.getOrderMetadata(
+					order
+				).put(
+					"analyticsProject", analyticsProjectJSONObject
+				).toString()
+			).build(),
+			order.getId(),
+			MarketplaceConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED);
 	}
 
 	@PostMapping("license-key-type-free")
@@ -353,45 +375,6 @@ public class ProvisioningRestController extends BaseRestController {
 
 		_provisioningService.postAppLicenseKey(
 			appLicenseKey, jwt, productPurchase);
-
-		_marketplaceService.completeOrder(
-			order.getId(),
-			MarketplaceConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED);
-	}
-
-	private void _provisionAnalyticsWorkspace(
-			JSONObject jsonObject, Order order)
-		throws Exception {
-
-		String analyticsProject = _analyticsService.getCorpProjectUuid(
-			order.getAccountExternalReferenceCode());
-
-		if (analyticsProject == null) {
-			JSONObject analyticsFormJSONObject = jsonObject.getJSONObject(
-				"analyticsForm");
-
-			analyticsFormJSONObject.put(
-				"corpProjectUuid", order.getAccountExternalReferenceCode());
-
-			analyticsProject = _analyticsService.provision(
-				analyticsFormJSONObject);
-		}
-
-		_marketplaceService.updateOrder(
-			HashMapBuilder.put(
-				"order-metadata",
-				new JSONObject(
-					GetterUtil.get(
-						order.getCustomFields(
-						).get(
-							"order-metadata"
-						),
-						"{}")
-				).put(
-					"analyticsProject", new JSONObject(analyticsProject)
-				).toString()
-			).build(),
-			order.getId(), MarketplaceConstants.ORDER_STATUS_COMPLETED);
 	}
 
 	@Autowired

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/AnalyticsService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/AnalyticsService.java
@@ -9,13 +9,13 @@ import com.liferay.client.extension.util.spring.boot3.service.BaseService;
 import com.liferay.petra.string.StringBundler;
 
 import java.util.Base64;
+import java.util.Objects;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.json.JSONObject;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -31,25 +31,65 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Component
 public class AnalyticsService extends BaseService {
 
+	public JSONObject getAnalyticsContextJSONObject(String environmentName) {
+		if (Objects.equals(environmentName, "internal")) {
+			return new JSONObject(
+			).put(
+				"emailAddress", _analyticsInternalAuthEmailAddress
+			).put(
+				"password", _analyticsInternalAuthPassword
+			).put(
+				"url", _analyticsInternalAuthUrl
+			);
+		}
+
+		return new JSONObject(
+		).put(
+			"emailAddress", _analyticsAuthEmailAddress
+		).put(
+			"password", _analyticsAuthPassword
+		).put(
+			"url", _analyticsAuthUrl
+		);
+	}
+
 	public String getAuthorization() {
+		return getAuthorization(getAnalyticsContextJSONObject(null));
+	}
+
+	public String getAuthorization(JSONObject analyticsContextJSONObject) {
 		Base64.Encoder encoder = Base64.getEncoder();
 
+		String emailAddress = analyticsContextJSONObject.getString(
+			"emailAddress");
+
 		String authorization =
-			_analyticsAuthEmailAddress + ":" + _analyticsAuthPassword;
+			emailAddress + ":" +
+				analyticsContextJSONObject.getString("password");
 
 		return "Basic " + encoder.encodeToString(authorization.getBytes());
 	}
 
-	public String getCorpProjectUuid(String corpProjectUuid) {
+	public JSONObject getCorpProjectUuidJSONObject(
+		JSONObject analyticsContextJSONObject, String corpProjectUuid) {
+
 		try {
-			return get(
-				getAuthorization(),
-				UriComponentsBuilder.fromUriString(
-					_analyticsAuthUrl
-				).path(
-					"/o/faro/main/project/corpProjectUuid/" + corpProjectUuid
-				).build(
-				).toUri());
+			JSONObject jsonObject = new JSONObject(
+				get(
+					getAuthorization(analyticsContextJSONObject),
+					UriComponentsBuilder.fromUriString(
+						analyticsContextJSONObject.getString("url")
+					).path(
+						"/o/faro/main/project/corpProjectUuid/" +
+							corpProjectUuid
+					).build(
+					).toUri()));
+
+			if (jsonObject.optInt("groupId") == 0) {
+				return null;
+			}
+
+			return jsonObject;
 		}
 		catch (WebClientResponseException webClientResponseException) {
 			if (_log.isDebugEnabled()) {
@@ -65,12 +105,20 @@ public class AnalyticsService extends BaseService {
 	}
 
 	public String provision(JSONObject jsonObject) throws Exception {
+		return provision(getAnalyticsContextJSONObject(null), jsonObject);
+	}
+
+	public String provision(
+			JSONObject analyticsContextJSONObject, JSONObject jsonObject)
+		throws Exception {
+
 		try {
 			String response = WebClient.builder(
 			).baseUrl(
-				_analyticsAuthUrl
+				analyticsContextJSONObject.getString("url")
 			).defaultHeader(
-				HttpHeaders.AUTHORIZATION, getAuthorization()
+				HttpHeaders.AUTHORIZATION,
+				getAuthorization(analyticsContextJSONObject)
 			).build(
 			).post(
 			).uri(
@@ -82,6 +130,12 @@ public class AnalyticsService extends BaseService {
 					"corpProjectName", jsonObject.optString("corpProjectName")
 				).with(
 					"corpProjectUuid", jsonObject.optString("corpProjectUuid")
+				).with(
+					"enableAutoConfiguration",
+					String.valueOf(
+						jsonObject.optBoolean("enableAutoConfiguration", true))
+				).with(
+					"friendlyURL", jsonObject.optString("friendlyURL")
 				).with(
 					"incidentReportEmailAddresses",
 					jsonObject.getJSONArray(
@@ -121,6 +175,32 @@ public class AnalyticsService extends BaseService {
 		}
 	}
 
+	public JSONObject provisionAnalyticsProject(
+			JSONObject analyticsFormJSONObject, String analyticsEnvironment,
+			String corpProjectUuid)
+		throws Exception {
+
+		JSONObject analyticsContextJSONObject = getAnalyticsContextJSONObject(
+			analyticsEnvironment);
+
+		JSONObject analyticsProjectJSONObject = getCorpProjectUuidJSONObject(
+			analyticsContextJSONObject, corpProjectUuid);
+
+		if (analyticsProjectJSONObject == null) {
+			if (Objects.equals(analyticsEnvironment, "internal")) {
+				analyticsFormJSONObject.put(
+					"serverLocation", "us-west1-ac-uat-c1");
+			}
+
+			analyticsFormJSONObject.put("corpProjectUuid", corpProjectUuid);
+
+			analyticsProjectJSONObject = new JSONObject(
+				provision(analyticsContextJSONObject, analyticsFormJSONObject));
+		}
+
+		return analyticsProjectJSONObject;
+	}
+
 	private static final Log _log = LogFactory.getLog(AnalyticsService.class);
 
 	@Value("${liferay.marketplace.analytics.auth.email.address}")
@@ -132,7 +212,13 @@ public class AnalyticsService extends BaseService {
 	@Value("${liferay.marketplace.analytics.auth.url}")
 	private String _analyticsAuthUrl;
 
-	@Autowired
-	private MarketplaceService _marketplaceService;
+	@Value("${liferay.marketplace.analytics.internal.auth.email.address}")
+	private String _analyticsInternalAuthEmailAddress;
+
+	@Value("${liferay.marketplace.analytics.internal.auth.password}")
+	private String _analyticsInternalAuthPassword;
+
+	@Value("${liferay.marketplace.analytics.internal.auth.url}")
+	private String _analyticsInternalAuthUrl;
 
 }

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/MarketplaceService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/MarketplaceService.java
@@ -12,6 +12,7 @@ import com.liferay.headless.admin.address.client.resource.v1_0.CountryResource;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.client.http.HttpInvoker;
 import com.liferay.headless.admin.user.client.pagination.Page;
+import com.liferay.headless.admin.user.client.resource.v1_0.AccountGroupResource;
 import com.liferay.headless.admin.user.client.resource.v1_0.AccountResource;
 import com.liferay.headless.admin.user.client.resource.v1_0.AccountRoleResource;
 import com.liferay.headless.admin.user.client.resource.v1_0.PostalAddressResource;
@@ -180,6 +181,17 @@ public class MarketplaceService extends BaseService {
 			"cloud-provisioning", cloudProvisioningJSONArray.toString());
 
 		updateOrder(customFields, order.getId(), order.getOrderStatus());
+	}
+
+	public AccountGroupResource getAccountGroupResource() throws Exception {
+		return AccountGroupResource.builder(
+		).header(
+			HttpHeaders.AUTHORIZATION,
+			_liferayOAuth2AccessTokenManager.getAuthorization(
+				"liferay-marketplace-etc-spring-boot-oahs")
+		).endpoint(
+			new URL(lxcDXPServerProtocol + "://" + lxcDXPMainDomain)
+		).build();
 	}
 
 	public AccountResource getAccountResource() throws Exception {

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/resources/application-default.properties
@@ -5,6 +5,9 @@
 liferay.marketplace.analytics.auth.email.address=${LIFERAY_MARKETPLACE_ANALYTICS_AUTH_EMAIL_ADDRESS}
 liferay.marketplace.analytics.auth.password=${LIFERAY_MARKETPLACE_ANALYTICS_AUTH_PASSWORD}
 liferay.marketplace.analytics.auth.url=${LIFERAY_MARKETPLACE_ANALYTICS_AUTH_URL}
+liferay.marketplace.analytics.internal.auth.email.address=${LIFERAY_MARKETPLACE_ANALYTICS_INTERNAL_AUTH_EMAIL_ADDRESS:}
+liferay.marketplace.analytics.internal.auth.password=${LIFERAY_MARKETPLACE_ANALYTICS_INTERNAL_AUTH_PASSWORD:}
+liferay.marketplace.analytics.internal.auth.url=${LIFERAY_MARKETPLACE_ANALYTICS_INTERNAL_AUTH_URL:}
 liferay.marketplace.console.auth.email.address=${LIFERAY_MARKETPLACE_CONSOLE_AUTH_EMAIL_ADDRESS}
 liferay.marketplace.console.auth.password=${LIFERAY_MARKETPLACE_CONSOLE_AUTH_PASSWORD}
 liferay.marketplace.console.auth.url=${LIFERAY_MARKETPLACE_CONSOLE_AUTH_URL}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93361

## What Is Being Fixed

The marketplace provisioning backend had no path for the Liferay Data Platform (LDP) private beta. The analytics integration could also only target a single Analytics Cloud instance, the project lookup returned only a bare UUID string with no way to tell an empty result from a real one, and orders were updated through a path that allowed multiple redundant updates.

## How It Is Being Fixed

The analytics auth context (email address, password, and URL) is now resolved through a context JSON object selected by environment name, so production can talk to a second, "internal" Analytics Cloud alongside the default one. New `liferay.marketplace.analytics.internal.auth.*` properties back the internal environment. The project lookup returns the full project JSON and treats a `groupId` of `0` as not found, and a new `provisionAnalyticsProject` helper looks up or provisions a project for a given environment, supporting the new `enableAutoConfiguration` and `friendlyURL` form fields.

The product purchase handler now routes the `ai-hub` and `liferay-data-platform` solution types independently. The LDP add-on creates a "3 Months Limited Beta" product purchase through Koroneiki, provisions an internal analytics project, and completes the order. The provisioning controller completes the order explicitly after posting the app license key instead of relying on a separate update step, preventing the multiple order updates. `MarketplaceService` also exposes an `AccountGroupResource`.

## Why Are There No Tests?

These are Spring Boot client-extension files in `liferay-marketplace-workspace` with no test harness; the changes are validated manually against the running marketplace.